### PR TITLE
feat(analytics): US-014 to US-018 — InventoryIssues + Analytics Modules

### DIFF
--- a/src/Modules/Analytics/AnalyticsModuleExtensions.cs
+++ b/src/Modules/Analytics/AnalyticsModuleExtensions.cs
@@ -1,0 +1,19 @@
+using System.Data;
+using IMS.Modular.Modules.Analytics.Infrastructure;
+using Microsoft.Data.Sqlite;
+
+namespace IMS.Modular.Modules.Analytics;
+
+public static class AnalyticsModuleExtensions
+{
+    public static IServiceCollection AddAnalyticsModule(this IServiceCollection services, IConfiguration configuration)
+    {
+        var connectionString = configuration.GetConnectionString("DefaultConnection")!;
+
+        // Dapper read connection (shared SQLite file)
+        services.AddScoped<IDbConnection>(_ => new SqliteConnection(connectionString));
+        services.AddScoped<IAnalyticsReadRepository, AnalyticsReadRepository>();
+
+        return services;
+    }
+}

--- a/src/Modules/Analytics/Api/AnalyticsModule.cs
+++ b/src/Modules/Analytics/Api/AnalyticsModule.cs
@@ -1,0 +1,190 @@
+using IMS.Modular.Modules.Analytics.Application.DTOs;
+using IMS.Modular.Modules.Analytics.Application.Queries;
+using IMS.Modular.Shared.Abstractions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace IMS.Modular.Modules.Analytics.Api;
+
+public class AnalyticsModule : IEndpointModule
+{
+    public static IEndpointRouteBuilder Map(IEndpointRouteBuilder endpoints)
+    {
+        MapIssueAnalytics(endpoints);
+        MapUserAnalytics(endpoints);
+        MapDashboard(endpoints);
+        MapInventoryAnalytics(endpoints);
+        return endpoints;
+    }
+
+    // ── US-015: Issue Analytics (/api/analytics/issues) ───────────────────
+
+    private static void MapIssueAnalytics(IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints
+            .MapGroup("/api/analytics/issues")
+            .WithTags("Analytics - Issues")
+            .RequireAuthorization();
+
+        group.MapGet("/summary", GetIssueSummary).WithName("GetIssueSummary");
+        group.MapGet("/trends", GetIssueTrends).WithName("GetIssueTrends");
+        group.MapGet("/resolution-time", GetIssueResolutionTime).WithName("GetIssueResolutionTime");
+        group.MapGet("/by-status", GetIssuesByStatus).WithName("GetIssueStatsByStatus");
+        group.MapGet("/by-priority", GetIssuesByPriority).WithName("GetIssueStatsByPriority");
+        group.MapGet("/by-assignee", GetIssuesByAssignee).WithName("GetIssueStatsByAssignee");
+        group.MapGet("/suggest-assignee", GetAssignSuggestion).WithName("GetAssignSuggestion");
+        group.MapGet("/statistics", GetIssueStatsByStatus).WithName("GetIssueStatistics");
+    }
+
+    private static async Task<IResult> GetIssueSummary(IMediator mediator, CancellationToken ct)
+        => Results.Ok(await mediator.Send(new GetIssueSummaryQuery(), ct));
+
+    private static async Task<IResult> GetIssueTrends(
+        IMediator mediator, [FromQuery] int days = 30, CancellationToken ct = default)
+        => Results.Ok(await mediator.Send(new GetIssueTrendsQuery(days), ct));
+
+    private static async Task<IResult> GetIssueResolutionTime(IMediator mediator, CancellationToken ct)
+        => Results.Ok(await mediator.Send(new GetIssueResolutionTimeQuery(), ct));
+
+    private static async Task<IResult> GetIssuesByStatus(IMediator mediator, CancellationToken ct)
+        => Results.Ok(await mediator.Send(new GetIssueStatsByStatusQuery(), ct));
+
+    private static async Task<IResult> GetIssuesByPriority(IMediator mediator, CancellationToken ct)
+        => Results.Ok(await mediator.Send(new GetIssueStatsByPriorityQuery(), ct));
+
+    private static async Task<IResult> GetIssuesByAssignee(IMediator mediator, CancellationToken ct)
+        => Results.Ok(await mediator.Send(new GetIssueStatsByAssigneeQuery(), ct));
+
+    private static async Task<IResult> GetAssignSuggestion(IMediator mediator, CancellationToken ct)
+        => Results.Ok(await mediator.Send(new GetAssignSuggestionQuery(), ct));
+
+    private static async Task<IResult> GetIssueStatsByStatus(IMediator mediator, CancellationToken ct)
+        => Results.Ok(await mediator.Send(new GetIssueStatsByStatusQuery(), ct));
+
+    // ── US-016: User Workload (/api/analytics/users) ──────────────────────
+
+    private static void MapUserAnalytics(IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints
+            .MapGroup("/api/analytics/users")
+            .WithTags("Analytics - Users")
+            .RequireAuthorization();
+
+        group.MapGet("/workload", GetAllUsersWorkload).WithName("GetAllUsersWorkload");
+        group.MapGet("/workload/{userId:guid}", GetUserWorkload).WithName("GetUserWorkload");
+        group.MapGet("/{userId:guid}/statistics", GetUserStatistics).WithName("GetUserStatistics");
+    }
+
+    private static async Task<IResult> GetAllUsersWorkload(IMediator mediator, CancellationToken ct)
+        => Results.Ok(await mediator.Send(new GetAllUsersWorkloadQuery(), ct));
+
+    private static async Task<IResult> GetUserWorkload(Guid userId, IMediator mediator, CancellationToken ct)
+    {
+        var result = await mediator.Send(new GetUserWorkloadQuery(userId), ct);
+        return result is null ? Results.NotFound() : Results.Ok(result);
+    }
+
+    private static async Task<IResult> GetUserStatistics(Guid userId, IMediator mediator, CancellationToken ct)
+    {
+        var result = await mediator.Send(new GetUserStatisticsQuery(userId), ct);
+        return result is null ? Results.NotFound() : Results.Ok(result);
+    }
+
+    // ── US-017: Dashboard & Export (/api/analytics) ───────────────────────
+
+    private static void MapDashboard(IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints
+            .MapGroup("/api/analytics")
+            .WithTags("Analytics - Dashboard")
+            .RequireAuthorization();
+
+        group.MapGet("/dashboard", GetDashboard).WithName("GetDashboard");
+        group.MapGet("/export", ExportData).WithName("ExportDataGet");
+        group.MapPost("/export", ExportDataPost).WithName("ExportDataPost");
+    }
+
+    private static async Task<IResult> GetDashboard(IMediator mediator, CancellationToken ct)
+        => Results.Ok(await mediator.Send(new GetDashboardQuery(), ct));
+
+    private static async Task<IResult> ExportData(
+        IMediator mediator,
+        [FromQuery] string format = "json",
+        [FromQuery] string? module = null,
+        [FromQuery] DateTime? from = null,
+        [FromQuery] DateTime? to = null,
+        CancellationToken ct = default)
+    {
+        var result = await mediator.Send(new ExportDataQuery(format, module, from, to), ct);
+        return Results.File(result.Data, result.ContentType, result.FileName);
+    }
+
+    private static async Task<IResult> ExportDataPost(
+        ExportParametersRequest req, IMediator mediator, CancellationToken ct)
+    {
+        var result = await mediator.Send(new ExportDataQuery(req.Format, req.Module, req.From, req.To), ct);
+        return Results.File(result.Data, result.ContentType, result.FileName);
+    }
+
+    // ── US-018: Inventory Analytics (/api/inventory/analytics) ───────────
+
+    private static void MapInventoryAnalytics(IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints
+            .MapGroup("/api/inventory/analytics")
+            .WithTags("Analytics - Inventory")
+            .RequireAuthorization();
+
+        group.MapGet("/value", GetInventoryValue).WithName("GetInventoryValue");
+        group.MapGet("/summary", GetInventorySummary).WithName("GetInventorySummary");
+        group.MapGet("/stock-status", GetStockStatusDistribution).WithName("GetStockStatusDistribution");
+        group.MapGet("/stock-trends", GetStockTrends).WithName("GetStockTrends");
+        group.MapGet("/categories", GetCategoryDistribution).WithName("GetCategoryDistribution");
+        group.MapGet("/turnover", GetTurnoverRate).WithName("GetTurnoverRate");
+        group.MapGet("/expiring", GetExpiringProducts).WithName("GetExpiringProducts");
+        group.MapGet("/location-capacity", GetLocationCapacity).WithName("GetLocationCapacity");
+        group.MapGet("/supplier-performance", GetSupplierPerformance).WithName("GetSupplierPerformance");
+        group.MapGet("/top-products", GetTopProducts).WithName("GetTopProducts");
+    }
+
+    private static async Task<IResult> GetInventoryValue(IMediator mediator, CancellationToken ct)
+        => Results.Ok(await mediator.Send(new GetInventoryValueQuery(), ct));
+
+    private static async Task<IResult> GetInventorySummary(IMediator mediator, CancellationToken ct)
+        => Results.Ok(await mediator.Send(new GetInventorySummaryQuery(), ct));
+
+    private static async Task<IResult> GetStockStatusDistribution(IMediator mediator, CancellationToken ct)
+        => Results.Ok(await mediator.Send(new GetStockStatusDistributionQuery(), ct));
+
+    private static async Task<IResult> GetStockTrends(
+        IMediator mediator, [FromQuery] int days = 30, CancellationToken ct = default)
+        => Results.Ok(await mediator.Send(new GetStockTrendsQuery(days), ct));
+
+    private static async Task<IResult> GetCategoryDistribution(IMediator mediator, CancellationToken ct)
+        => Results.Ok(await mediator.Send(new GetCategoryDistributionQuery(), ct));
+
+    private static async Task<IResult> GetTurnoverRate(
+        IMediator mediator, [FromQuery] int topN = 20, CancellationToken ct = default)
+        => Results.Ok(await mediator.Send(new GetTurnoverRateQuery(topN), ct));
+
+    private static async Task<IResult> GetExpiringProducts(
+        IMediator mediator,
+        [FromQuery] int daysAhead = 30,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20,
+        CancellationToken ct = default)
+        => Results.Ok(await mediator.Send(new GetExpiringProductsQuery(daysAhead, page, pageSize), ct));
+
+    private static async Task<IResult> GetLocationCapacity(IMediator mediator, CancellationToken ct)
+        => Results.Ok(await mediator.Send(new GetLocationCapacityQuery(), ct));
+
+    private static async Task<IResult> GetSupplierPerformance(IMediator mediator, CancellationToken ct)
+        => Results.Ok(await mediator.Send(new GetSupplierPerformanceQuery(), ct));
+
+    private static async Task<IResult> GetTopProducts(
+        IMediator mediator,
+        [FromQuery] int topN = 10,
+        [FromQuery] string orderBy = "value",
+        CancellationToken ct = default)
+        => Results.Ok(await mediator.Send(new GetTopProductsQuery(topN, orderBy), ct));
+}

--- a/src/Modules/Analytics/Application/DTOs/AnalyticsDtos.cs
+++ b/src/Modules/Analytics/Application/DTOs/AnalyticsDtos.cs
@@ -1,0 +1,143 @@
+namespace IMS.Modular.Modules.Analytics.Application.DTOs;
+
+// ── US-015: Issue Analytics ───────────────────────────────────────────────
+
+public record IssueSummaryDto(
+    int Total,
+    int Open,
+    int InProgress,
+    int Testing,
+    int Resolved,
+    int Closed,
+    int Overdue,
+    int DueToday);
+
+public record IssueTrendDto(
+    string Date,
+    int Created,
+    int Resolved,
+    int Closed);
+
+public record IssueResolutionTimeDto(
+    string Priority,
+    double AvgResolutionHours,
+    double MinResolutionHours,
+    double MaxResolutionHours,
+    int SampleSize);
+
+public record IssueStatsByStatusDto(string Status, int Count, double Percentage);
+public record IssueStatsByPriorityDto(string Priority, int Count, double Percentage);
+public record IssueStatsByAssigneeDto(Guid? AssigneeId, int Open, int InProgress, int Resolved, int Closed, int Total);
+public record AssignSuggestionDto(Guid UserId, int CurrentLoad, int Resolved, double AvgResolutionHours);
+
+// ── US-016: User Workload Analytics ──────────────────────────────────────
+
+public record UserWorkloadSummaryDto(
+    Guid UserId,
+    int TotalAssigned,
+    int Open,
+    int InProgress,
+    int Resolved,
+    int Closed,
+    int Overdue);
+
+public record UserWorkloadDetailDto(
+    Guid UserId,
+    int TotalAssigned,
+    int Open,
+    int InProgress,
+    int Resolved,
+    int Closed,
+    int Overdue,
+    double AvgResolutionHours,
+    double CompletionRate);
+
+public record UserStatisticsDto(
+    Guid UserId,
+    int TotalResolved,
+    double AvgResolutionHours,
+    double CompletionRate,
+    int CurrentLoad);
+
+// ── US-017: Dashboard & Export ────────────────────────────────────────────
+
+public record DashboardDto(
+    IssueSummaryDto IssueSummary,
+    InventorySummaryDto InventorySummary,
+    IReadOnlyList<IssueTrendDto> RecentTrends,
+    IReadOnlyList<UserWorkloadSummaryDto> TopAssignees,
+    DateTime GeneratedAt);
+
+public record ExportParametersRequest(
+    string Format = "json",
+    string? Module = null,
+    DateTime? From = null,
+    DateTime? To = null);
+
+// ── US-018: Inventory Analytics ───────────────────────────────────────────
+
+public record InventoryValueDto(
+    decimal TotalValue,
+    decimal TotalCostValue,
+    IReadOnlyList<CategoryValueDto> ByCategory,
+    IReadOnlyList<LocationValueDto> ByLocation);
+
+public record CategoryValueDto(string Category, int ProductCount, decimal TotalValue, decimal TotalCostValue);
+public record LocationValueDto(Guid? LocationId, string LocationName, int ProductCount, decimal TotalValue);
+
+public record InventorySummaryDto(
+    int TotalProducts,
+    int ActiveProducts,
+    int DiscontinuedProducts,
+    int LowStockProducts,
+    int OutOfStockProducts,
+    int OverstockProducts,
+    decimal TotalInventoryValue);
+
+public record StockStatusDistributionDto(string Status, int Count, double Percentage);
+
+public record StockTrendDto(string Date, int TotalIn, int TotalOut, int NetChange);
+
+public record CategoryDistributionDto(string Category, int Count, double Percentage);
+
+public record TurnoverRateDto(
+    Guid ProductId,
+    string ProductName,
+    string SKU,
+    int TotalMovements,
+    int TotalOut,
+    double TurnoverRate);
+
+public record ExpiringProductDto(
+    Guid ProductId,
+    string ProductName,
+    string SKU,
+    int CurrentStock,
+    DateTime ExpiryDate,
+    int DaysUntilExpiry);
+
+public record LocationCapacityDto(
+    Guid LocationId,
+    string LocationName,
+    string LocationCode,
+    int Capacity,
+    int CurrentStock,
+    double UtilizationPercent);
+
+public record SupplierPerformanceDto(
+    Guid SupplierId,
+    string SupplierName,
+    string SupplierCode,
+    int TotalProducts,
+    int TotalPurchases,
+    decimal TotalPurchaseValue);
+
+public record TopProductDto(
+    Guid ProductId,
+    string ProductName,
+    string SKU,
+    string Category,
+    int CurrentStock,
+    decimal UnitPrice,
+    decimal TotalValue,
+    int TotalMovements);

--- a/src/Modules/Analytics/Application/Handlers/AnalyticsHandlers.cs
+++ b/src/Modules/Analytics/Application/Handlers/AnalyticsHandlers.cs
@@ -1,0 +1,195 @@
+using IMS.Modular.Modules.Analytics.Application.DTOs;
+using IMS.Modular.Modules.Analytics.Application.Queries;
+using IMS.Modular.Modules.Analytics.Infrastructure;
+using MediatR;
+
+namespace IMS.Modular.Modules.Analytics.Application.Handlers;
+
+// ── US-015: Issue Analytics ───────────────────────────────────────────────
+
+public class GetIssueSummaryHandler(IAnalyticsReadRepository repo)
+    : IRequestHandler<GetIssueSummaryQuery, IssueSummaryDto>
+{
+    public Task<IssueSummaryDto> Handle(GetIssueSummaryQuery q, CancellationToken ct)
+        => repo.GetIssueSummaryAsync(ct);
+}
+
+public class GetIssueTrendsHandler(IAnalyticsReadRepository repo)
+    : IRequestHandler<GetIssueTrendsQuery, IReadOnlyList<IssueTrendDto>>
+{
+    public Task<IReadOnlyList<IssueTrendDto>> Handle(GetIssueTrendsQuery q, CancellationToken ct)
+        => repo.GetIssueTrendsAsync(q.Days, ct);
+}
+
+public class GetIssueResolutionTimeHandler(IAnalyticsReadRepository repo)
+    : IRequestHandler<GetIssueResolutionTimeQuery, IReadOnlyList<IssueResolutionTimeDto>>
+{
+    public Task<IReadOnlyList<IssueResolutionTimeDto>> Handle(GetIssueResolutionTimeQuery q, CancellationToken ct)
+        => repo.GetIssueResolutionTimeAsync(ct);
+}
+
+public class GetIssueStatsByStatusHandler(IAnalyticsReadRepository repo)
+    : IRequestHandler<GetIssueStatsByStatusQuery, IReadOnlyList<IssueStatsByStatusDto>>
+{
+    public Task<IReadOnlyList<IssueStatsByStatusDto>> Handle(GetIssueStatsByStatusQuery q, CancellationToken ct)
+        => repo.GetIssueStatsByStatusAsync(ct);
+}
+
+public class GetIssueStatsByPriorityHandler(IAnalyticsReadRepository repo)
+    : IRequestHandler<GetIssueStatsByPriorityQuery, IReadOnlyList<IssueStatsByPriorityDto>>
+{
+    public Task<IReadOnlyList<IssueStatsByPriorityDto>> Handle(GetIssueStatsByPriorityQuery q, CancellationToken ct)
+        => repo.GetIssueStatsByPriorityAsync(ct);
+}
+
+public class GetIssueStatsByAssigneeHandler(IAnalyticsReadRepository repo)
+    : IRequestHandler<GetIssueStatsByAssigneeQuery, IReadOnlyList<IssueStatsByAssigneeDto>>
+{
+    public Task<IReadOnlyList<IssueStatsByAssigneeDto>> Handle(GetIssueStatsByAssigneeQuery q, CancellationToken ct)
+        => repo.GetIssueStatsByAssigneeAsync(ct);
+}
+
+public class GetAssignSuggestionHandler(IAnalyticsReadRepository repo)
+    : IRequestHandler<GetAssignSuggestionQuery, IReadOnlyList<AssignSuggestionDto>>
+{
+    public Task<IReadOnlyList<AssignSuggestionDto>> Handle(GetAssignSuggestionQuery q, CancellationToken ct)
+        => repo.GetAssignSuggestionsAsync(ct);
+}
+
+// ── US-016: User Workload ─────────────────────────────────────────────────
+
+public class GetAllUsersWorkloadHandler(IAnalyticsReadRepository repo)
+    : IRequestHandler<GetAllUsersWorkloadQuery, IReadOnlyList<UserWorkloadSummaryDto>>
+{
+    public Task<IReadOnlyList<UserWorkloadSummaryDto>> Handle(GetAllUsersWorkloadQuery q, CancellationToken ct)
+        => repo.GetAllUsersWorkloadAsync(ct);
+}
+
+public class GetUserWorkloadHandler(IAnalyticsReadRepository repo)
+    : IRequestHandler<GetUserWorkloadQuery, UserWorkloadDetailDto?>
+{
+    public Task<UserWorkloadDetailDto?> Handle(GetUserWorkloadQuery q, CancellationToken ct)
+        => repo.GetUserWorkloadAsync(q.UserId, ct);
+}
+
+public class GetUserStatisticsHandler(IAnalyticsReadRepository repo)
+    : IRequestHandler<GetUserStatisticsQuery, UserStatisticsDto?>
+{
+    public Task<UserStatisticsDto?> Handle(GetUserStatisticsQuery q, CancellationToken ct)
+        => repo.GetUserStatisticsAsync(q.UserId, ct);
+}
+
+// ── US-017: Dashboard & Export ────────────────────────────────────────────
+
+public class GetDashboardHandler(IAnalyticsReadRepository repo)
+    : IRequestHandler<GetDashboardQuery, DashboardDto>
+{
+    public async Task<DashboardDto> Handle(GetDashboardQuery q, CancellationToken ct)
+    {
+        var issueSummary = await repo.GetIssueSummaryAsync(ct);
+        var inventorySummary = await repo.GetInventorySummaryAsync(ct);
+        var trends = await repo.GetIssueTrendsAsync(7, ct);
+        var topAssignees = await repo.GetAllUsersWorkloadAsync(ct);
+
+        return new DashboardDto(
+            issueSummary,
+            inventorySummary,
+            trends,
+            topAssignees.Take(5).ToList(),
+            DateTime.UtcNow);
+    }
+}
+
+public class ExportDataHandler(IAnalyticsReadRepository repo)
+    : IRequestHandler<ExportDataQuery, ExportResultDto>
+{
+    public async Task<ExportResultDto> Handle(ExportDataQuery q, CancellationToken ct)
+    {
+        var format = q.Format.ToLower();
+        var data = await repo.ExportToJsonAsync(q.Module, q.From, q.To);
+
+        return format switch
+        {
+            "csv" => new ExportResultDto(
+                $"ims-export-{DateTime.UtcNow:yyyyMMdd-HHmmss}.csv",
+                "text/csv",
+                data),
+            _ => new ExportResultDto(
+                $"ims-export-{DateTime.UtcNow:yyyyMMdd-HHmmss}.json",
+                "application/json",
+                data)
+        };
+    }
+}
+
+// ── US-018: Inventory Analytics ───────────────────────────────────────────
+
+public class GetInventoryValueHandler(IAnalyticsReadRepository repo)
+    : IRequestHandler<GetInventoryValueQuery, InventoryValueDto>
+{
+    public Task<InventoryValueDto> Handle(GetInventoryValueQuery q, CancellationToken ct)
+        => repo.GetInventoryValueAsync(ct);
+}
+
+public class GetInventorySummaryHandler(IAnalyticsReadRepository repo)
+    : IRequestHandler<GetInventorySummaryQuery, InventorySummaryDto>
+{
+    public Task<InventorySummaryDto> Handle(GetInventorySummaryQuery q, CancellationToken ct)
+        => repo.GetInventorySummaryAsync(ct);
+}
+
+public class GetStockStatusDistributionHandler(IAnalyticsReadRepository repo)
+    : IRequestHandler<GetStockStatusDistributionQuery, IReadOnlyList<StockStatusDistributionDto>>
+{
+    public Task<IReadOnlyList<StockStatusDistributionDto>> Handle(GetStockStatusDistributionQuery q, CancellationToken ct)
+        => repo.GetStockStatusDistributionAsync(ct);
+}
+
+public class GetStockTrendsHandler(IAnalyticsReadRepository repo)
+    : IRequestHandler<GetStockTrendsQuery, IReadOnlyList<StockTrendDto>>
+{
+    public Task<IReadOnlyList<StockTrendDto>> Handle(GetStockTrendsQuery q, CancellationToken ct)
+        => repo.GetStockTrendsAsync(q.Days, ct);
+}
+
+public class GetCategoryDistributionHandler(IAnalyticsReadRepository repo)
+    : IRequestHandler<GetCategoryDistributionQuery, IReadOnlyList<CategoryDistributionDto>>
+{
+    public Task<IReadOnlyList<CategoryDistributionDto>> Handle(GetCategoryDistributionQuery q, CancellationToken ct)
+        => repo.GetCategoryDistributionAsync(ct);
+}
+
+public class GetTurnoverRateHandler(IAnalyticsReadRepository repo)
+    : IRequestHandler<GetTurnoverRateQuery, IReadOnlyList<TurnoverRateDto>>
+{
+    public Task<IReadOnlyList<TurnoverRateDto>> Handle(GetTurnoverRateQuery q, CancellationToken ct)
+        => repo.GetTurnoverRateAsync(q.TopN, ct);
+}
+
+public class GetExpiringProductsHandler(IAnalyticsReadRepository repo)
+    : IRequestHandler<GetExpiringProductsQuery, IReadOnlyList<ExpiringProductDto>>
+{
+    public Task<IReadOnlyList<ExpiringProductDto>> Handle(GetExpiringProductsQuery q, CancellationToken ct)
+        => repo.GetExpiringProductsAsync(q.DaysAhead, q.Page, q.PageSize, ct);
+}
+
+public class GetLocationCapacityHandler(IAnalyticsReadRepository repo)
+    : IRequestHandler<GetLocationCapacityQuery, IReadOnlyList<LocationCapacityDto>>
+{
+    public Task<IReadOnlyList<LocationCapacityDto>> Handle(GetLocationCapacityQuery q, CancellationToken ct)
+        => repo.GetLocationCapacityAsync(ct);
+}
+
+public class GetSupplierPerformanceHandler(IAnalyticsReadRepository repo)
+    : IRequestHandler<GetSupplierPerformanceQuery, IReadOnlyList<SupplierPerformanceDto>>
+{
+    public Task<IReadOnlyList<SupplierPerformanceDto>> Handle(GetSupplierPerformanceQuery q, CancellationToken ct)
+        => repo.GetSupplierPerformanceAsync(ct);
+}
+
+public class GetTopProductsHandler(IAnalyticsReadRepository repo)
+    : IRequestHandler<GetTopProductsQuery, IReadOnlyList<TopProductDto>>
+{
+    public Task<IReadOnlyList<TopProductDto>> Handle(GetTopProductsQuery q, CancellationToken ct)
+        => repo.GetTopProductsAsync(q.TopN, q.OrderBy, ct);
+}

--- a/src/Modules/Analytics/Application/Queries/AnalyticsQueries.cs
+++ b/src/Modules/Analytics/Application/Queries/AnalyticsQueries.cs
@@ -1,0 +1,149 @@
+using IMS.Modular.Modules.Analytics.Application.DTOs;
+using IMS.Modular.Shared.Abstractions;
+using MediatR;
+
+namespace IMS.Modular.Modules.Analytics.Application.Queries;
+
+// ── US-015: Issue Analytics ───────────────────────────────────────────────
+
+public record GetIssueSummaryQuery() : IRequest<IssueSummaryDto>, ICacheable
+{
+    public string CacheKeyPrefix => "analytics-issue-summary";
+    public TimeSpan? CacheDuration => TimeSpan.FromMinutes(10);
+}
+
+public record GetIssueTrendsQuery(int Days = 30) : IRequest<IReadOnlyList<IssueTrendDto>>, ICacheable
+{
+    public string CacheKeyPrefix => "analytics-issue-trends";
+    public TimeSpan? CacheDuration => TimeSpan.FromMinutes(10);
+}
+
+public record GetIssueResolutionTimeQuery() : IRequest<IReadOnlyList<IssueResolutionTimeDto>>, ICacheable
+{
+    public string CacheKeyPrefix => "analytics-issue-resolution-time";
+    public TimeSpan? CacheDuration => TimeSpan.FromMinutes(10);
+}
+
+public record GetIssueStatsByStatusQuery() : IRequest<IReadOnlyList<IssueStatsByStatusDto>>, ICacheable
+{
+    public string CacheKeyPrefix => "analytics-issue-stats-status";
+    public TimeSpan? CacheDuration => TimeSpan.FromMinutes(10);
+}
+
+public record GetIssueStatsByPriorityQuery() : IRequest<IReadOnlyList<IssueStatsByPriorityDto>>, ICacheable
+{
+    public string CacheKeyPrefix => "analytics-issue-stats-priority";
+    public TimeSpan? CacheDuration => TimeSpan.FromMinutes(10);
+}
+
+public record GetIssueStatsByAssigneeQuery() : IRequest<IReadOnlyList<IssueStatsByAssigneeDto>>, ICacheable
+{
+    public string CacheKeyPrefix => "analytics-issue-stats-assignee";
+    public TimeSpan? CacheDuration => TimeSpan.FromMinutes(10);
+}
+
+public record GetAssignSuggestionQuery() : IRequest<IReadOnlyList<AssignSuggestionDto>>, ICacheable
+{
+    public string CacheKeyPrefix => "analytics-issue-assign-suggestion";
+    public TimeSpan? CacheDuration => TimeSpan.FromMinutes(5);
+}
+
+// ── US-016: User Workload ─────────────────────────────────────────────────
+
+public record GetAllUsersWorkloadQuery() : IRequest<IReadOnlyList<UserWorkloadSummaryDto>>, ICacheable
+{
+    public string CacheKeyPrefix => "analytics-users-workload";
+    public TimeSpan? CacheDuration => TimeSpan.FromMinutes(5);
+}
+
+public record GetUserWorkloadQuery(Guid UserId) : IRequest<UserWorkloadDetailDto?>, ICacheable
+{
+    public string CacheKeyPrefix => "analytics-user-workload";
+    public TimeSpan? CacheDuration => TimeSpan.FromMinutes(5);
+}
+
+public record GetUserStatisticsQuery(Guid UserId) : IRequest<UserStatisticsDto?>, ICacheable
+{
+    public string CacheKeyPrefix => "analytics-user-statistics";
+    public TimeSpan? CacheDuration => TimeSpan.FromMinutes(5);
+}
+
+// ── US-017: Dashboard & Export ────────────────────────────────────────────
+
+public record GetDashboardQuery() : IRequest<DashboardDto>, ICacheable
+{
+    public string CacheKeyPrefix => "analytics-dashboard";
+    public TimeSpan? CacheDuration => TimeSpan.FromMinutes(10);
+}
+
+public record ExportDataQuery(
+    string Format = "json",
+    string? Module = null,
+    DateTime? From = null,
+    DateTime? To = null) : IRequest<ExportResultDto>;
+
+public record ExportResultDto(string FileName, string ContentType, byte[] Data);
+
+// ── US-018: Inventory Analytics ───────────────────────────────────────────
+
+public record GetInventoryValueQuery() : IRequest<InventoryValueDto>, ICacheable
+{
+    public string CacheKeyPrefix => "analytics-inventory-value";
+    public TimeSpan? CacheDuration => TimeSpan.FromMinutes(10);
+}
+
+public record GetInventorySummaryQuery() : IRequest<InventorySummaryDto>, ICacheable
+{
+    public string CacheKeyPrefix => "analytics-inventory-summary";
+    public TimeSpan? CacheDuration => TimeSpan.FromMinutes(10);
+}
+
+public record GetStockStatusDistributionQuery() : IRequest<IReadOnlyList<StockStatusDistributionDto>>, ICacheable
+{
+    public string CacheKeyPrefix => "analytics-stock-status";
+    public TimeSpan? CacheDuration => TimeSpan.FromMinutes(10);
+}
+
+public record GetStockTrendsQuery(int Days = 30) : IRequest<IReadOnlyList<StockTrendDto>>, ICacheable
+{
+    public string CacheKeyPrefix => "analytics-stock-trends";
+    public TimeSpan? CacheDuration => TimeSpan.FromMinutes(10);
+}
+
+public record GetCategoryDistributionQuery() : IRequest<IReadOnlyList<CategoryDistributionDto>>, ICacheable
+{
+    public string CacheKeyPrefix => "analytics-category-distribution";
+    public TimeSpan? CacheDuration => TimeSpan.FromMinutes(10);
+}
+
+public record GetTurnoverRateQuery(int TopN = 20) : IRequest<IReadOnlyList<TurnoverRateDto>>, ICacheable
+{
+    public string CacheKeyPrefix => "analytics-turnover-rate";
+    public TimeSpan? CacheDuration => TimeSpan.FromMinutes(10);
+}
+
+public record GetExpiringProductsQuery(int DaysAhead = 30, int Page = 1, int PageSize = 20)
+    : IRequest<IReadOnlyList<ExpiringProductDto>>, ICacheable
+{
+    public string CacheKeyPrefix => "analytics-expiring-products";
+    public TimeSpan? CacheDuration => TimeSpan.FromMinutes(10);
+}
+
+public record GetLocationCapacityQuery() : IRequest<IReadOnlyList<LocationCapacityDto>>, ICacheable
+{
+    public string CacheKeyPrefix => "analytics-location-capacity";
+    public TimeSpan? CacheDuration => TimeSpan.FromMinutes(10);
+}
+
+public record GetSupplierPerformanceQuery() : IRequest<IReadOnlyList<SupplierPerformanceDto>>, ICacheable
+{
+    public string CacheKeyPrefix => "analytics-supplier-performance";
+    public TimeSpan? CacheDuration => TimeSpan.FromMinutes(10);
+}
+
+public record GetTopProductsQuery(int TopN = 10, string OrderBy = "value")
+    : IRequest<IReadOnlyList<TopProductDto>>, ICacheable
+{
+    public string CacheKeyPrefix => "analytics-top-products";
+    public TimeSpan? CacheDuration => TimeSpan.FromMinutes(10);
+}

--- a/src/Modules/Analytics/Infrastructure/AnalyticsReadRepository.cs
+++ b/src/Modules/Analytics/Infrastructure/AnalyticsReadRepository.cs
@@ -1,0 +1,454 @@
+using System.Data;
+using System.Text;
+using System.Text.Json;
+using Dapper;
+using IMS.Modular.Modules.Analytics.Application.DTOs;
+
+namespace IMS.Modular.Modules.Analytics.Infrastructure;
+
+file static class GH
+{
+    internal static string Up(Guid id) => id.ToString().ToUpperInvariant();
+}
+
+public interface IAnalyticsReadRepository
+{
+    // Issue Analytics (US-015)
+    Task<IssueSummaryDto> GetIssueSummaryAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<IssueTrendDto>> GetIssueTrendsAsync(int days, CancellationToken ct = default);
+    Task<IReadOnlyList<IssueResolutionTimeDto>> GetIssueResolutionTimeAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<IssueStatsByStatusDto>> GetIssueStatsByStatusAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<IssueStatsByPriorityDto>> GetIssueStatsByPriorityAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<IssueStatsByAssigneeDto>> GetIssueStatsByAssigneeAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<AssignSuggestionDto>> GetAssignSuggestionsAsync(CancellationToken ct = default);
+
+    // User Workload (US-016)
+    Task<IReadOnlyList<UserWorkloadSummaryDto>> GetAllUsersWorkloadAsync(CancellationToken ct = default);
+    Task<UserWorkloadDetailDto?> GetUserWorkloadAsync(Guid userId, CancellationToken ct = default);
+    Task<UserStatisticsDto?> GetUserStatisticsAsync(Guid userId, CancellationToken ct = default);
+
+    // Inventory Analytics (US-018)
+    Task<InventoryValueDto> GetInventoryValueAsync(CancellationToken ct = default);
+    Task<InventorySummaryDto> GetInventorySummaryAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<StockStatusDistributionDto>> GetStockStatusDistributionAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<StockTrendDto>> GetStockTrendsAsync(int days, CancellationToken ct = default);
+    Task<IReadOnlyList<CategoryDistributionDto>> GetCategoryDistributionAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<TurnoverRateDto>> GetTurnoverRateAsync(int topN, CancellationToken ct = default);
+    Task<IReadOnlyList<ExpiringProductDto>> GetExpiringProductsAsync(int daysAhead, int page, int pageSize, CancellationToken ct = default);
+    Task<IReadOnlyList<LocationCapacityDto>> GetLocationCapacityAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<SupplierPerformanceDto>> GetSupplierPerformanceAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<TopProductDto>> GetTopProductsAsync(int topN, string orderBy, CancellationToken ct = default);
+
+    // Export (US-017)
+    Task<byte[]> ExportToJsonAsync(string? module, DateTime? from, DateTime? to);
+}
+
+public class AnalyticsReadRepository(IDbConnection connection) : IAnalyticsReadRepository
+{
+    // ── Issue Analytics ───────────────────────────────────────────────────
+
+    public async Task<IssueSummaryDto> GetIssueSummaryAsync(CancellationToken ct = default)
+    {
+        const string sql = """
+            SELECT
+                COUNT(*) AS Total,
+                SUM(CASE WHEN Status = 'Open' THEN 1 ELSE 0 END) AS Open,
+                SUM(CASE WHEN Status = 'InProgress' THEN 1 ELSE 0 END) AS InProgress,
+                SUM(CASE WHEN Status = 'Testing' THEN 1 ELSE 0 END) AS Testing,
+                SUM(CASE WHEN Status = 'Resolved' THEN 1 ELSE 0 END) AS Resolved,
+                SUM(CASE WHEN Status = 'Closed' THEN 1 ELSE 0 END) AS Closed,
+                SUM(CASE WHEN DueDate < CURRENT_TIMESTAMP AND Status NOT IN ('Resolved','Closed') THEN 1 ELSE 0 END) AS Overdue,
+                SUM(CASE WHEN DATE(DueDate) = DATE('now') AND Status NOT IN ('Resolved','Closed') THEN 1 ELSE 0 END) AS DueToday
+            FROM Issues
+            """;
+        var row = await connection.QuerySingleAsync<dynamic>(sql);
+        return new IssueSummaryDto(
+            (int)(row.Total ?? 0), (int)(row.Open ?? 0), (int)(row.InProgress ?? 0),
+            (int)(row.Testing ?? 0), (int)(row.Resolved ?? 0), (int)(row.Closed ?? 0),
+            (int)(row.Overdue ?? 0), (int)(row.DueToday ?? 0));
+    }
+
+    public async Task<IReadOnlyList<IssueTrendDto>> GetIssueTrendsAsync(int days, CancellationToken ct = default)
+    {
+        var sql = $"""
+            WITH dates AS (
+                SELECT DATE('now', '-' || (ROW_NUMBER() OVER() - 1) || ' days') AS d
+                FROM (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5
+                      UNION SELECT 6 UNION SELECT 7) t1,
+                     (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5) t2
+                LIMIT {days}
+            )
+            SELECT
+                dates.d AS Date,
+                COUNT(CASE WHEN DATE(i.CreatedAt) = dates.d THEN 1 END) AS Created,
+                COUNT(CASE WHEN DATE(i.UpdatedAt) = dates.d AND i.Status = 'Resolved' THEN 1 END) AS Resolved,
+                COUNT(CASE WHEN DATE(i.UpdatedAt) = dates.d AND i.Status = 'Closed' THEN 1 END) AS Closed
+            FROM dates
+            LEFT JOIN Issues i ON DATE(i.CreatedAt) <= dates.d
+            GROUP BY dates.d
+            ORDER BY dates.d ASC
+            """;
+
+        // Simplified version that works reliably with SQLite
+        var fromDate = DateTime.UtcNow.AddDays(-days);
+        const string simpleSql = """
+            SELECT DATE(CreatedAt) AS Date,
+                   COUNT(*) AS Created,
+                   SUM(CASE WHEN Status = 'Resolved' THEN 1 ELSE 0 END) AS Resolved,
+                   SUM(CASE WHEN Status = 'Closed' THEN 1 ELSE 0 END) AS Closed
+            FROM Issues
+            WHERE CreatedAt >= @FromDate
+            GROUP BY DATE(CreatedAt)
+            ORDER BY Date ASC
+            """;
+        var rows = await connection.QueryAsync<IssueTrendDto>(simpleSql, new { FromDate = fromDate.ToString("o") });
+        return rows.AsList();
+    }
+
+    public async Task<IReadOnlyList<IssueResolutionTimeDto>> GetIssueResolutionTimeAsync(CancellationToken ct = default)
+    {
+        const string sql = """
+            SELECT
+                Priority,
+                AVG(CAST((JULIANDAY(UpdatedAt) - JULIANDAY(CreatedAt)) * 24 AS REAL)) AS AvgResolutionHours,
+                MIN(CAST((JULIANDAY(UpdatedAt) - JULIANDAY(CreatedAt)) * 24 AS REAL)) AS MinResolutionHours,
+                MAX(CAST((JULIANDAY(UpdatedAt) - JULIANDAY(CreatedAt)) * 24 AS REAL)) AS MaxResolutionHours,
+                COUNT(*) AS SampleSize
+            FROM Issues
+            WHERE Status IN ('Resolved', 'Closed') AND UpdatedAt IS NOT NULL
+            GROUP BY Priority
+            """;
+        var rows = await connection.QueryAsync<IssueResolutionTimeDto>(sql);
+        return rows.AsList();
+    }
+
+    public async Task<IReadOnlyList<IssueStatsByStatusDto>> GetIssueStatsByStatusAsync(CancellationToken ct = default)
+    {
+        const string sql = """
+            SELECT Status, COUNT(*) AS Count,
+                   ROUND(COUNT(*) * 100.0 / SUM(COUNT(*)) OVER(), 2) AS Percentage
+            FROM Issues
+            GROUP BY Status
+            ORDER BY Count DESC
+            """;
+        return (await connection.QueryAsync<IssueStatsByStatusDto>(sql)).AsList();
+    }
+
+    public async Task<IReadOnlyList<IssueStatsByPriorityDto>> GetIssueStatsByPriorityAsync(CancellationToken ct = default)
+    {
+        const string sql = """
+            SELECT Priority, COUNT(*) AS Count,
+                   ROUND(COUNT(*) * 100.0 / SUM(COUNT(*)) OVER(), 2) AS Percentage
+            FROM Issues
+            GROUP BY Priority
+            ORDER BY Count DESC
+            """;
+        return (await connection.QueryAsync<IssueStatsByPriorityDto>(sql)).AsList();
+    }
+
+    public async Task<IReadOnlyList<IssueStatsByAssigneeDto>> GetIssueStatsByAssigneeAsync(CancellationToken ct = default)
+    {
+        const string sql = """
+            SELECT AssigneeId,
+                   SUM(CASE WHEN Status = 'Open' THEN 1 ELSE 0 END) AS Open,
+                   SUM(CASE WHEN Status = 'InProgress' THEN 1 ELSE 0 END) AS InProgress,
+                   SUM(CASE WHEN Status = 'Resolved' THEN 1 ELSE 0 END) AS Resolved,
+                   SUM(CASE WHEN Status = 'Closed' THEN 1 ELSE 0 END) AS Closed,
+                   COUNT(*) AS Total
+            FROM Issues
+            WHERE AssigneeId IS NOT NULL
+            GROUP BY AssigneeId
+            ORDER BY Total DESC
+            """;
+        return (await connection.QueryAsync<IssueStatsByAssigneeDto>(sql)).AsList();
+    }
+
+    public async Task<IReadOnlyList<AssignSuggestionDto>> GetAssignSuggestionsAsync(CancellationToken ct = default)
+    {
+        const string sql = """
+            SELECT AssigneeId AS UserId,
+                   COUNT(CASE WHEN Status IN ('Open','InProgress') THEN 1 END) AS CurrentLoad,
+                   COUNT(CASE WHEN Status IN ('Resolved','Closed') THEN 1 END) AS Resolved,
+                   AVG(CASE WHEN Status IN ('Resolved','Closed') AND UpdatedAt IS NOT NULL
+                        THEN CAST((JULIANDAY(UpdatedAt) - JULIANDAY(CreatedAt)) * 24 AS REAL)
+                   END) AS AvgResolutionHours
+            FROM Issues
+            WHERE AssigneeId IS NOT NULL
+            GROUP BY AssigneeId
+            ORDER BY CurrentLoad ASC, AvgResolutionHours ASC
+            LIMIT 5
+            """;
+        return (await connection.QueryAsync<AssignSuggestionDto>(sql)).AsList();
+    }
+
+    // ── User Workload ─────────────────────────────────────────────────────
+
+    public async Task<IReadOnlyList<UserWorkloadSummaryDto>> GetAllUsersWorkloadAsync(CancellationToken ct = default)
+    {
+        const string sql = """
+            SELECT AssigneeId AS UserId,
+                   COUNT(*) AS TotalAssigned,
+                   SUM(CASE WHEN Status = 'Open' THEN 1 ELSE 0 END) AS Open,
+                   SUM(CASE WHEN Status = 'InProgress' THEN 1 ELSE 0 END) AS InProgress,
+                   SUM(CASE WHEN Status = 'Resolved' THEN 1 ELSE 0 END) AS Resolved,
+                   SUM(CASE WHEN Status = 'Closed' THEN 1 ELSE 0 END) AS Closed,
+                   SUM(CASE WHEN DueDate < CURRENT_TIMESTAMP AND Status NOT IN ('Resolved','Closed') THEN 1 ELSE 0 END) AS Overdue
+            FROM Issues
+            WHERE AssigneeId IS NOT NULL
+            GROUP BY AssigneeId
+            ORDER BY TotalAssigned DESC
+            """;
+        return (await connection.QueryAsync<UserWorkloadSummaryDto>(sql)).AsList();
+    }
+
+    public async Task<UserWorkloadDetailDto?> GetUserWorkloadAsync(Guid userId, CancellationToken ct = default)
+    {
+        const string sql = """
+            SELECT AssigneeId AS UserId,
+                   COUNT(*) AS TotalAssigned,
+                   SUM(CASE WHEN Status = 'Open' THEN 1 ELSE 0 END) AS Open,
+                   SUM(CASE WHEN Status = 'InProgress' THEN 1 ELSE 0 END) AS InProgress,
+                   SUM(CASE WHEN Status = 'Resolved' THEN 1 ELSE 0 END) AS Resolved,
+                   SUM(CASE WHEN Status = 'Closed' THEN 1 ELSE 0 END) AS Closed,
+                   SUM(CASE WHEN DueDate < CURRENT_TIMESTAMP AND Status NOT IN ('Resolved','Closed') THEN 1 ELSE 0 END) AS Overdue,
+                   AVG(CASE WHEN Status IN ('Resolved','Closed') AND UpdatedAt IS NOT NULL
+                        THEN CAST((JULIANDAY(UpdatedAt) - JULIANDAY(CreatedAt)) * 24 AS REAL) END) AS AvgResolutionHours,
+                   ROUND(COUNT(CASE WHEN Status IN ('Resolved','Closed') THEN 1 END) * 100.0 / COUNT(*), 2) AS CompletionRate
+            FROM Issues
+            WHERE UPPER(AssigneeId) = @UserId
+            GROUP BY AssigneeId
+            """;
+        return await connection.QuerySingleOrDefaultAsync<UserWorkloadDetailDto>(sql, new { UserId = GH.Up(userId) });
+    }
+
+    public async Task<UserStatisticsDto?> GetUserStatisticsAsync(Guid userId, CancellationToken ct = default)
+    {
+        const string sql = """
+            SELECT AssigneeId AS UserId,
+                   COUNT(CASE WHEN Status IN ('Resolved','Closed') THEN 1 END) AS TotalResolved,
+                   AVG(CASE WHEN Status IN ('Resolved','Closed') AND UpdatedAt IS NOT NULL
+                        THEN CAST((JULIANDAY(UpdatedAt) - JULIANDAY(CreatedAt)) * 24 AS REAL) END) AS AvgResolutionHours,
+                   ROUND(COUNT(CASE WHEN Status IN ('Resolved','Closed') THEN 1 END) * 100.0 / COUNT(*), 2) AS CompletionRate,
+                   COUNT(CASE WHEN Status IN ('Open','InProgress') THEN 1 END) AS CurrentLoad
+            FROM Issues
+            WHERE UPPER(AssigneeId) = @UserId
+            GROUP BY AssigneeId
+            """;
+        return await connection.QuerySingleOrDefaultAsync<UserStatisticsDto>(sql, new { UserId = GH.Up(userId) });
+    }
+
+    // ── Inventory Analytics ───────────────────────────────────────────────
+
+    public async Task<InventoryValueDto> GetInventoryValueAsync(CancellationToken ct = default)
+    {
+        const string totalSql = """
+            SELECT
+                SUM(CurrentStock * UnitPrice) AS TotalValue,
+                SUM(CurrentStock * CostPrice) AS TotalCostValue
+            FROM Products WHERE IsActive = 1
+            """;
+        var total = await connection.QuerySingleAsync<dynamic>(totalSql);
+
+        const string byCatSql = """
+            SELECT Category, COUNT(*) AS ProductCount,
+                   SUM(CurrentStock * UnitPrice) AS TotalValue,
+                   SUM(CurrentStock * CostPrice) AS TotalCostValue
+            FROM Products WHERE IsActive = 1
+            GROUP BY Category ORDER BY TotalValue DESC
+            """;
+        var byCategory = (await connection.QueryAsync<CategoryValueDto>(byCatSql)).AsList();
+
+        const string byLocSql = """
+            SELECT p.LocationId, COALESCE(l.Name, 'No Location') AS LocationName,
+                   COUNT(*) AS ProductCount,
+                   SUM(p.CurrentStock * p.UnitPrice) AS TotalValue
+            FROM Products p
+            LEFT JOIN Locations l ON UPPER(l.Id) = UPPER(p.LocationId)
+            WHERE p.IsActive = 1
+            GROUP BY p.LocationId ORDER BY TotalValue DESC
+            """;
+        var byLocation = (await connection.QueryAsync<LocationValueDto>(byLocSql)).AsList();
+
+        return new InventoryValueDto(
+            (decimal)(total.TotalValue ?? 0),
+            (decimal)(total.TotalCostValue ?? 0),
+            byCategory,
+            byLocation);
+    }
+
+    public async Task<InventorySummaryDto> GetInventorySummaryAsync(CancellationToken ct = default)
+    {
+        const string sql = """
+            SELECT
+                COUNT(*) AS TotalProducts,
+                SUM(CASE WHEN IsActive = 1 AND StockStatus != 'Discontinued' THEN 1 ELSE 0 END) AS ActiveProducts,
+                SUM(CASE WHEN StockStatus = 'Discontinued' THEN 1 ELSE 0 END) AS DiscontinuedProducts,
+                SUM(CASE WHEN StockStatus = 'LowStock' THEN 1 ELSE 0 END) AS LowStockProducts,
+                SUM(CASE WHEN StockStatus = 'OutOfStock' THEN 1 ELSE 0 END) AS OutOfStockProducts,
+                SUM(CASE WHEN StockStatus = 'Overstock' THEN 1 ELSE 0 END) AS OverstockProducts,
+                SUM(CurrentStock * UnitPrice) AS TotalInventoryValue
+            FROM Products
+            """;
+        var row = await connection.QuerySingleAsync<dynamic>(sql);
+        return new InventorySummaryDto(
+            (int)(row.TotalProducts ?? 0),
+            (int)(row.ActiveProducts ?? 0),
+            (int)(row.DiscontinuedProducts ?? 0),
+            (int)(row.LowStockProducts ?? 0),
+            (int)(row.OutOfStockProducts ?? 0),
+            (int)(row.OverstockProducts ?? 0),
+            (decimal)(row.TotalInventoryValue ?? 0));
+    }
+
+    public async Task<IReadOnlyList<StockStatusDistributionDto>> GetStockStatusDistributionAsync(CancellationToken ct = default)
+    {
+        const string sql = """
+            SELECT StockStatus AS Status, COUNT(*) AS Count,
+                   ROUND(COUNT(*) * 100.0 / SUM(COUNT(*)) OVER(), 2) AS Percentage
+            FROM Products
+            GROUP BY StockStatus ORDER BY Count DESC
+            """;
+        return (await connection.QueryAsync<StockStatusDistributionDto>(sql)).AsList();
+    }
+
+    public async Task<IReadOnlyList<StockTrendDto>> GetStockTrendsAsync(int days, CancellationToken ct = default)
+    {
+        var fromDate = DateTime.UtcNow.AddDays(-days);
+        const string sql = """
+            SELECT DATE(MovementDate) AS Date,
+                   SUM(CASE WHEN MovementType IN ('StockIn','Purchase','InitialStock','Return') THEN Quantity ELSE 0 END) AS TotalIn,
+                   SUM(CASE WHEN MovementType IN ('StockOut','Sale','Damage','Loss','Expired') THEN Quantity ELSE 0 END) AS TotalOut,
+                   SUM(CASE WHEN MovementType IN ('StockIn','Purchase','InitialStock','Return') THEN Quantity ELSE 0 END) -
+                   SUM(CASE WHEN MovementType IN ('StockOut','Sale','Damage','Loss','Expired') THEN Quantity ELSE 0 END) AS NetChange
+            FROM StockMovements
+            WHERE MovementDate >= @FromDate
+            GROUP BY DATE(MovementDate)
+            ORDER BY Date ASC
+            """;
+        return (await connection.QueryAsync<StockTrendDto>(sql, new { FromDate = fromDate.ToString("o") })).AsList();
+    }
+
+    public async Task<IReadOnlyList<CategoryDistributionDto>> GetCategoryDistributionAsync(CancellationToken ct = default)
+    {
+        const string sql = """
+            SELECT Category, COUNT(*) AS Count,
+                   ROUND(COUNT(*) * 100.0 / SUM(COUNT(*)) OVER(), 2) AS Percentage
+            FROM Products
+            GROUP BY Category ORDER BY Count DESC
+            """;
+        return (await connection.QueryAsync<CategoryDistributionDto>(sql)).AsList();
+    }
+
+    public async Task<IReadOnlyList<TurnoverRateDto>> GetTurnoverRateAsync(int topN, CancellationToken ct = default)
+    {
+        var sql = $"""
+            SELECT p.Id AS ProductId, p.Name AS ProductName, p.SKU,
+                   COUNT(sm.Id) AS TotalMovements,
+                   SUM(CASE WHEN sm.MovementType IN ('StockOut','Sale','Damage','Loss','Expired') THEN sm.Quantity ELSE 0 END) AS TotalOut,
+                   ROUND(CAST(SUM(CASE WHEN sm.MovementType IN ('StockOut','Sale','Damage','Loss','Expired') THEN sm.Quantity ELSE 0 END) AS REAL)
+                         / NULLIF(AVG(p.CurrentStock), 0), 4) AS TurnoverRate
+            FROM Products p
+            LEFT JOIN StockMovements sm ON UPPER(sm.ProductId) = UPPER(p.Id)
+            GROUP BY p.Id, p.Name, p.SKU
+            ORDER BY TurnoverRate DESC
+            LIMIT {topN}
+            """;
+        return (await connection.QueryAsync<TurnoverRateDto>(sql)).AsList();
+    }
+
+    public async Task<IReadOnlyList<ExpiringProductDto>> GetExpiringProductsAsync(int daysAhead, int page, int pageSize, CancellationToken ct = default)
+    {
+        var until = DateTime.UtcNow.AddDays(daysAhead);
+        var sql = $"""
+            SELECT Id AS ProductId, Name AS ProductName, SKU,
+                   CurrentStock, ExpiryDate,
+                   CAST(JULIANDAY(ExpiryDate) - JULIANDAY('now') AS INTEGER) AS DaysUntilExpiry
+            FROM Products
+            WHERE ExpiryDate IS NOT NULL AND ExpiryDate <= @Until AND ExpiryDate >= DATE('now')
+              AND IsActive = 1
+            ORDER BY ExpiryDate ASC
+            LIMIT {pageSize} OFFSET {(page - 1) * pageSize}
+            """;
+        return (await connection.QueryAsync<ExpiringProductDto>(sql, new { Until = until.ToString("o") })).AsList();
+    }
+
+    public async Task<IReadOnlyList<LocationCapacityDto>> GetLocationCapacityAsync(CancellationToken ct = default)
+    {
+        const string sql = """
+            SELECT l.Id AS LocationId, l.Name AS LocationName, l.Code AS LocationCode,
+                   l.Capacity,
+                   COALESCE(SUM(p.CurrentStock), 0) AS CurrentStock,
+                   ROUND(COALESCE(SUM(p.CurrentStock), 0) * 100.0 / NULLIF(l.Capacity, 0), 2) AS UtilizationPercent
+            FROM Locations l
+            LEFT JOIN Products p ON UPPER(p.LocationId) = UPPER(l.Id) AND p.IsActive = 1
+            WHERE l.IsActive = 1
+            GROUP BY l.Id, l.Name, l.Code, l.Capacity
+            ORDER BY UtilizationPercent DESC
+            """;
+        return (await connection.QueryAsync<LocationCapacityDto>(sql)).AsList();
+    }
+
+    public async Task<IReadOnlyList<SupplierPerformanceDto>> GetSupplierPerformanceAsync(CancellationToken ct = default)
+    {
+        const string sql = """
+            SELECT s.Id AS SupplierId, s.Name AS SupplierName, s.Code AS SupplierCode,
+                   COUNT(DISTINCT p.Id) AS TotalProducts,
+                   COUNT(sm.Id) AS TotalPurchases,
+                   SUM(CASE WHEN sm.MovementType = 'Purchase' THEN sm.Quantity * p.CostPrice ELSE 0 END) AS TotalPurchaseValue
+            FROM Suppliers s
+            LEFT JOIN Products p ON UPPER(p.SupplierId) = UPPER(s.Id)
+            LEFT JOIN StockMovements sm ON UPPER(sm.ProductId) = UPPER(p.Id)
+                AND sm.MovementType IN ('StockIn','Purchase')
+            WHERE s.IsActive = 1
+            GROUP BY s.Id, s.Name, s.Code
+            ORDER BY TotalPurchaseValue DESC
+            """;
+        return (await connection.QueryAsync<SupplierPerformanceDto>(sql)).AsList();
+    }
+
+    public async Task<IReadOnlyList<TopProductDto>> GetTopProductsAsync(int topN, string orderBy, CancellationToken ct = default)
+    {
+        var orderClause = orderBy.ToLower() switch
+        {
+            "movement" => "TotalMovements DESC",
+            "stock"    => "CurrentStock DESC",
+            _          => "TotalValue DESC"
+        };
+
+        var sql = $"""
+            SELECT p.Id AS ProductId, p.Name AS ProductName, p.SKU, p.Category,
+                   p.CurrentStock, p.UnitPrice,
+                   p.CurrentStock * p.UnitPrice AS TotalValue,
+                   COUNT(sm.Id) AS TotalMovements
+            FROM Products p
+            LEFT JOIN StockMovements sm ON UPPER(sm.ProductId) = UPPER(p.Id)
+            WHERE p.IsActive = 1
+            GROUP BY p.Id, p.Name, p.SKU, p.Category, p.CurrentStock, p.UnitPrice
+            ORDER BY {orderClause}
+            LIMIT {topN}
+            """;
+        return (await connection.QueryAsync<TopProductDto>(sql)).AsList();
+    }
+
+    // ── Export helper ─────────────────────────────────────────────────────
+
+    public async Task<byte[]> ExportToJsonAsync(string? module, DateTime? from, DateTime? to)
+    {
+        object data = module?.ToLower() switch
+        {
+            "issues" => await GetIssueSummaryAsync(),
+            "inventory" => await GetInventorySummaryAsync(),
+            "users" => await GetAllUsersWorkloadAsync(),
+            _ => new
+            {
+                Issues = await GetIssueSummaryAsync(),
+                Inventory = await GetInventorySummaryAsync(),
+                Users = await GetAllUsersWorkloadAsync(),
+                GeneratedAt = DateTime.UtcNow
+            }
+        };
+
+        var json = JsonSerializer.Serialize(data, new JsonSerializerOptions { WriteIndented = true });
+        return Encoding.UTF8.GetBytes(json);
+    }
+}

--- a/src/Modules/InventoryIssues/Api/InventoryIssuesModule.cs
+++ b/src/Modules/InventoryIssues/Api/InventoryIssuesModule.cs
@@ -1,0 +1,145 @@
+using IMS.Modular.Modules.InventoryIssues.Application.Commands;
+using IMS.Modular.Modules.InventoryIssues.Application.DTOs;
+using IMS.Modular.Modules.InventoryIssues.Application.Queries;
+using IMS.Modular.Modules.InventoryIssues.Domain.Enums;
+using IMS.Modular.Shared.Abstractions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace IMS.Modular.Modules.InventoryIssues.Api;
+
+public class InventoryIssuesModule : IEndpointModule
+{
+    public static IEndpointRouteBuilder Map(IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints
+            .MapGroup("/api/inventory-issues")
+            .WithTags("Inventory Issues")
+            .RequireAuthorization();
+
+        // List / search
+        group.MapGet("/", GetAll).WithName("GetInventoryIssues");
+        group.MapGet("/{id:guid}", GetById).WithName("GetInventoryIssueById");
+        group.MapGet("/overdue", GetOverdue).WithName("GetOverdueInventoryIssues");
+        group.MapGet("/high-priority", GetHighPriority).WithName("GetHighPriorityInventoryIssues");
+        group.MapGet("/statistics", GetStatistics).WithName("GetInventoryIssueStatistics");
+
+        // CRUD
+        group.MapPost("/", Create).WithName("CreateInventoryIssue");
+        group.MapPut("/{id:guid}", Update).WithName("UpdateInventoryIssue");
+        group.MapDelete("/{id:guid}", Delete).WithName("DeleteInventoryIssue");
+
+        // Lifecycle
+        group.MapPatch("/{id:guid}/assign", Assign).WithName("AssignInventoryIssue");
+        group.MapPatch("/{id:guid}/resolve", Resolve).WithName("ResolveInventoryIssue");
+        group.MapPatch("/{id:guid}/close", Close).WithName("CloseInventoryIssue");
+        group.MapPatch("/{id:guid}/reopen", Reopen).WithName("ReopenInventoryIssue");
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> GetAll(
+        IMediator mediator,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20,
+        [FromQuery] string? status = null,
+        [FromQuery] string? priority = null,
+        [FromQuery] string? type = null,
+        [FromQuery] Guid? productId = null,
+        [FromQuery] Guid? locationId = null,
+        [FromQuery] Guid? reporterId = null,
+        [FromQuery] Guid? assigneeId = null,
+        [FromQuery] string? search = null,
+        CancellationToken ct = default)
+    {
+        Enum.TryParse<InventoryIssueStatus>(status, true, out var statusEnum);
+        Enum.TryParse<InventoryIssuePriority>(priority, true, out var priorityEnum);
+        Enum.TryParse<InventoryIssueType>(type, true, out var typeEnum);
+
+        var result = await mediator.Send(new GetInventoryIssuesQuery(
+            page, pageSize,
+            string.IsNullOrEmpty(status) ? null : statusEnum,
+            string.IsNullOrEmpty(priority) ? null : priorityEnum,
+            string.IsNullOrEmpty(type) ? null : typeEnum,
+            productId, locationId, reporterId, assigneeId, search), ct);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> GetById(Guid id, IMediator mediator, CancellationToken ct)
+    {
+        var issue = await mediator.Send(new GetInventoryIssueByIdQuery(id), ct);
+        return issue is null ? Results.NotFound() : Results.Ok(issue);
+    }
+
+    private static async Task<IResult> GetOverdue(
+        IMediator mediator, [FromQuery] int page = 1, [FromQuery] int pageSize = 20, CancellationToken ct = default)
+    {
+        var result = await mediator.Send(new GetOverdueInventoryIssuesQuery(page, pageSize), ct);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> GetHighPriority(
+        IMediator mediator, [FromQuery] int page = 1, [FromQuery] int pageSize = 20, CancellationToken ct = default)
+    {
+        var result = await mediator.Send(new GetHighPriorityInventoryIssuesQuery(page, pageSize), ct);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> GetStatistics(IMediator mediator, CancellationToken ct)
+    {
+        var stats = await mediator.Send(new GetInventoryIssueStatisticsQuery(), ct);
+        return Results.Ok(stats);
+    }
+
+    private static async Task<IResult> Create(
+        CreateInventoryIssueRequest req, IMediator mediator, CancellationToken ct)
+    {
+        var id = await mediator.Send(new CreateInventoryIssueCommand(
+            req.Title, req.Description, req.Type, req.Priority, req.ReporterId,
+            req.ProductId, req.LocationId, req.AffectedQuantity, req.EstimatedLoss, req.DueDate), ct);
+        return Results.Created($"/api/inventory-issues/{id}", new { id });
+    }
+
+    private static async Task<IResult> Update(
+        Guid id, UpdateInventoryIssueRequest req, IMediator mediator, CancellationToken ct)
+    {
+        var ok = await mediator.Send(new UpdateInventoryIssueCommand(
+            id, req.Title, req.Description, req.Type, req.Priority,
+            req.ProductId, req.LocationId, req.AffectedQuantity, req.EstimatedLoss, req.DueDate), ct);
+        return ok ? Results.Ok() : Results.NotFound();
+    }
+
+    private static async Task<IResult> Delete(Guid id, IMediator mediator, CancellationToken ct)
+    {
+        var ok = await mediator.Send(new DeleteInventoryIssueCommand(id), ct);
+        return ok ? Results.NoContent() : Results.NotFound();
+    }
+
+    private static async Task<IResult> Assign(
+        Guid id, AssignInventoryIssueRequest req, IMediator mediator,
+        IUserContext user, CancellationToken ct)
+    {
+        var ok = await mediator.Send(new AssignInventoryIssueCommand(id, req.AssigneeId, user.UserId.GetValueOrDefault()), ct);
+        return ok ? Results.Ok() : Results.NotFound();
+    }
+
+    private static async Task<IResult> Resolve(
+        Guid id, ResolveInventoryIssueRequest req, IMediator mediator,
+        IUserContext user, CancellationToken ct)
+    {
+        var ok = await mediator.Send(new ResolveInventoryIssueCommand(id, req.ResolutionNotes, user.UserId.GetValueOrDefault()), ct);
+        return ok ? Results.Ok() : Results.NotFound();
+    }
+
+    private static async Task<IResult> Close(Guid id, IMediator mediator, IUserContext user, CancellationToken ct)
+    {
+        var ok = await mediator.Send(new CloseInventoryIssueCommand(id, user.UserId.GetValueOrDefault()), ct);
+        return ok ? Results.Ok() : Results.NotFound();
+    }
+
+    private static async Task<IResult> Reopen(Guid id, IMediator mediator, IUserContext user, CancellationToken ct)
+    {
+        var ok = await mediator.Send(new ReopenInventoryIssueCommand(id, user.UserId.GetValueOrDefault()), ct);
+        return ok ? Results.Ok() : Results.NotFound();
+    }
+}

--- a/src/Modules/InventoryIssues/Application/Commands/InventoryIssueCommands.cs
+++ b/src/Modules/InventoryIssues/Application/Commands/InventoryIssueCommands.cs
@@ -1,0 +1,48 @@
+using IMS.Modular.Modules.InventoryIssues.Domain.Enums;
+using MediatR;
+
+namespace IMS.Modular.Modules.InventoryIssues.Application.Commands;
+
+public record CreateInventoryIssueCommand(
+    string Title,
+    string Description,
+    InventoryIssueType Type,
+    InventoryIssuePriority Priority,
+    Guid ReporterId,
+    Guid? ProductId,
+    Guid? LocationId,
+    int? AffectedQuantity,
+    decimal? EstimatedLoss,
+    DateTime? DueDate) : IRequest<Guid>;
+
+public record UpdateInventoryIssueCommand(
+    Guid Id,
+    string Title,
+    string Description,
+    InventoryIssueType Type,
+    InventoryIssuePriority Priority,
+    Guid? ProductId,
+    Guid? LocationId,
+    int? AffectedQuantity,
+    decimal? EstimatedLoss,
+    DateTime? DueDate) : IRequest<bool>;
+
+public record AssignInventoryIssueCommand(
+    Guid Id,
+    Guid AssigneeId,
+    Guid UserId) : IRequest<bool>;
+
+public record ResolveInventoryIssueCommand(
+    Guid Id,
+    string? ResolutionNotes,
+    Guid UserId) : IRequest<bool>;
+
+public record CloseInventoryIssueCommand(
+    Guid Id,
+    Guid UserId) : IRequest<bool>;
+
+public record ReopenInventoryIssueCommand(
+    Guid Id,
+    Guid UserId) : IRequest<bool>;
+
+public record DeleteInventoryIssueCommand(Guid Id) : IRequest<bool>;

--- a/src/Modules/InventoryIssues/Application/DTOs/InventoryIssueDtos.cs
+++ b/src/Modules/InventoryIssues/Application/DTOs/InventoryIssueDtos.cs
@@ -1,0 +1,30 @@
+using IMS.Modular.Modules.InventoryIssues.Domain.Enums;
+
+namespace IMS.Modular.Modules.InventoryIssues.Application.DTOs;
+
+public record CreateInventoryIssueRequest(
+    string Title,
+    string Description,
+    InventoryIssueType Type,
+    InventoryIssuePriority Priority,
+    Guid ReporterId,
+    Guid? ProductId = null,
+    Guid? LocationId = null,
+    int? AffectedQuantity = null,
+    decimal? EstimatedLoss = null,
+    DateTime? DueDate = null);
+
+public record UpdateInventoryIssueRequest(
+    string Title,
+    string Description,
+    InventoryIssueType Type,
+    InventoryIssuePriority Priority,
+    Guid? ProductId,
+    Guid? LocationId,
+    int? AffectedQuantity,
+    decimal? EstimatedLoss,
+    DateTime? DueDate);
+
+public record AssignInventoryIssueRequest(Guid AssigneeId);
+
+public record ResolveInventoryIssueRequest(string? ResolutionNotes);

--- a/src/Modules/InventoryIssues/Application/Handlers/InventoryIssueHandlers.cs
+++ b/src/Modules/InventoryIssues/Application/Handlers/InventoryIssueHandlers.cs
@@ -1,0 +1,139 @@
+using IMS.Modular.Modules.InventoryIssues.Application.Commands;
+using IMS.Modular.Modules.InventoryIssues.Application.Queries;
+using IMS.Modular.Modules.InventoryIssues.Domain.Entities;
+using IMS.Modular.Modules.InventoryIssues.Infrastructure;
+using IMS.Modular.Shared.Domain;
+using MediatR;
+
+namespace IMS.Modular.Modules.InventoryIssues.Application.Handlers;
+
+// ── Command Handlers ─────────────────────────────────────────────────────
+
+public class CreateInventoryIssueHandler(IInventoryIssueRepository repo)
+    : IRequestHandler<CreateInventoryIssueCommand, Guid>
+{
+    public async Task<Guid> Handle(CreateInventoryIssueCommand cmd, CancellationToken ct)
+    {
+        var issue = new InventoryIssue(
+            cmd.Title, cmd.Description, cmd.Type, cmd.Priority, cmd.ReporterId,
+            cmd.ProductId, cmd.LocationId, cmd.AffectedQuantity, cmd.EstimatedLoss, cmd.DueDate);
+        await repo.AddAsync(issue, ct);
+        return issue.Id;
+    }
+}
+
+public class UpdateInventoryIssueHandler(IInventoryIssueRepository repo)
+    : IRequestHandler<UpdateInventoryIssueCommand, bool>
+{
+    public async Task<bool> Handle(UpdateInventoryIssueCommand cmd, CancellationToken ct)
+    {
+        var issue = await repo.GetByIdAsync(cmd.Id, ct);
+        if (issue is null) return false;
+        issue.Update(cmd.Title, cmd.Description, cmd.Type, cmd.Priority,
+            cmd.ProductId, cmd.LocationId, cmd.AffectedQuantity, cmd.EstimatedLoss, cmd.DueDate);
+        await repo.UpdateAsync(issue, ct);
+        return true;
+    }
+}
+
+public class AssignInventoryIssueHandler(IInventoryIssueRepository repo)
+    : IRequestHandler<AssignInventoryIssueCommand, bool>
+{
+    public async Task<bool> Handle(AssignInventoryIssueCommand cmd, CancellationToken ct)
+    {
+        var issue = await repo.GetByIdAsync(cmd.Id, ct);
+        if (issue is null) return false;
+        issue.Assign(cmd.AssigneeId, cmd.UserId);
+        await repo.UpdateAsync(issue, ct);
+        return true;
+    }
+}
+
+public class ResolveInventoryIssueHandler(IInventoryIssueRepository repo)
+    : IRequestHandler<ResolveInventoryIssueCommand, bool>
+{
+    public async Task<bool> Handle(ResolveInventoryIssueCommand cmd, CancellationToken ct)
+    {
+        var issue = await repo.GetByIdAsync(cmd.Id, ct);
+        if (issue is null) return false;
+        issue.Resolve(cmd.ResolutionNotes, cmd.UserId);
+        await repo.UpdateAsync(issue, ct);
+        return true;
+    }
+}
+
+public class CloseInventoryIssueHandler(IInventoryIssueRepository repo)
+    : IRequestHandler<CloseInventoryIssueCommand, bool>
+{
+    public async Task<bool> Handle(CloseInventoryIssueCommand cmd, CancellationToken ct)
+    {
+        var issue = await repo.GetByIdAsync(cmd.Id, ct);
+        if (issue is null) return false;
+        issue.Close(cmd.UserId);
+        await repo.UpdateAsync(issue, ct);
+        return true;
+    }
+}
+
+public class ReopenInventoryIssueHandler(IInventoryIssueRepository repo)
+    : IRequestHandler<ReopenInventoryIssueCommand, bool>
+{
+    public async Task<bool> Handle(ReopenInventoryIssueCommand cmd, CancellationToken ct)
+    {
+        var issue = await repo.GetByIdAsync(cmd.Id, ct);
+        if (issue is null) return false;
+        issue.Reopen(cmd.UserId);
+        await repo.UpdateAsync(issue, ct);
+        return true;
+    }
+}
+
+public class DeleteInventoryIssueHandler(IInventoryIssueRepository repo)
+    : IRequestHandler<DeleteInventoryIssueCommand, bool>
+{
+    public async Task<bool> Handle(DeleteInventoryIssueCommand cmd, CancellationToken ct)
+    {
+        var issue = await repo.GetByIdAsync(cmd.Id, ct);
+        if (issue is null) return false;
+        await repo.DeleteAsync(issue, ct);
+        return true;
+    }
+}
+
+// ── Query Handlers ───────────────────────────────────────────────────────
+
+public class GetInventoryIssueByIdHandler(IInventoryIssueReadRepository read)
+    : IRequestHandler<GetInventoryIssueByIdQuery, InventoryIssueReadDto?>
+{
+    public Task<InventoryIssueReadDto?> Handle(GetInventoryIssueByIdQuery q, CancellationToken ct)
+        => read.GetByIdAsync(q.Id, ct);
+}
+
+public class GetInventoryIssuesHandler(IInventoryIssueReadRepository read)
+    : IRequestHandler<GetInventoryIssuesQuery, PagedResult<InventoryIssueSummaryDto>>
+{
+    public Task<PagedResult<InventoryIssueSummaryDto>> Handle(GetInventoryIssuesQuery q, CancellationToken ct)
+        => read.GetPagedAsync(q.Page, q.PageSize, q.Status, q.Priority, q.Type,
+            q.ProductId, q.LocationId, q.ReporterId, q.AssigneeId, q.Search, ct);
+}
+
+public class GetOverdueInventoryIssuesHandler(IInventoryIssueReadRepository read)
+    : IRequestHandler<GetOverdueInventoryIssuesQuery, PagedResult<InventoryIssueSummaryDto>>
+{
+    public Task<PagedResult<InventoryIssueSummaryDto>> Handle(GetOverdueInventoryIssuesQuery q, CancellationToken ct)
+        => read.GetOverdueAsync(q.Page, q.PageSize, ct);
+}
+
+public class GetHighPriorityInventoryIssuesHandler(IInventoryIssueReadRepository read)
+    : IRequestHandler<GetHighPriorityInventoryIssuesQuery, PagedResult<InventoryIssueSummaryDto>>
+{
+    public Task<PagedResult<InventoryIssueSummaryDto>> Handle(GetHighPriorityInventoryIssuesQuery q, CancellationToken ct)
+        => read.GetHighPriorityAsync(q.Page, q.PageSize, ct);
+}
+
+public class GetInventoryIssueStatisticsHandler(IInventoryIssueReadRepository read)
+    : IRequestHandler<GetInventoryIssueStatisticsQuery, InventoryIssueStatsDto>
+{
+    public Task<InventoryIssueStatsDto> Handle(GetInventoryIssueStatisticsQuery q, CancellationToken ct)
+        => read.GetStatisticsAsync(ct);
+}

--- a/src/Modules/InventoryIssues/Application/Queries/InventoryIssueQueries.cs
+++ b/src/Modules/InventoryIssues/Application/Queries/InventoryIssueQueries.cs
@@ -1,0 +1,45 @@
+using IMS.Modular.Modules.InventoryIssues.Domain.Enums;
+using IMS.Modular.Modules.InventoryIssues.Infrastructure;
+using IMS.Modular.Shared.Abstractions;
+using IMS.Modular.Shared.Domain;
+using MediatR;
+
+namespace IMS.Modular.Modules.InventoryIssues.Application.Queries;
+
+public record GetInventoryIssueByIdQuery(Guid Id) : IRequest<InventoryIssueReadDto?>;
+
+public record GetInventoryIssuesQuery(
+    int Page = 1,
+    int PageSize = 20,
+    InventoryIssueStatus? Status = null,
+    InventoryIssuePriority? Priority = null,
+    InventoryIssueType? Type = null,
+    Guid? ProductId = null,
+    Guid? LocationId = null,
+    Guid? ReporterId = null,
+    Guid? AssigneeId = null,
+    string? Search = null) : IRequest<PagedResult<InventoryIssueSummaryDto>>, ICacheable
+{
+    public string CacheKeyPrefix => "inventory-issues-list";
+    public TimeSpan? CacheDuration => TimeSpan.FromMinutes(2);
+}
+
+public record GetOverdueInventoryIssuesQuery(int Page = 1, int PageSize = 20)
+    : IRequest<PagedResult<InventoryIssueSummaryDto>>, ICacheable
+{
+    public string CacheKeyPrefix => "inventory-issues-overdue";
+    public TimeSpan? CacheDuration => TimeSpan.FromMinutes(2);
+}
+
+public record GetHighPriorityInventoryIssuesQuery(int Page = 1, int PageSize = 20)
+    : IRequest<PagedResult<InventoryIssueSummaryDto>>, ICacheable
+{
+    public string CacheKeyPrefix => "inventory-issues-high-priority";
+    public TimeSpan? CacheDuration => TimeSpan.FromMinutes(2);
+}
+
+public record GetInventoryIssueStatisticsQuery() : IRequest<InventoryIssueStatsDto>, ICacheable
+{
+    public string CacheKeyPrefix => "inventory-issues-stats";
+    public TimeSpan? CacheDuration => TimeSpan.FromMinutes(5);
+}

--- a/src/Modules/InventoryIssues/Application/Validators/InventoryIssueValidators.cs
+++ b/src/Modules/InventoryIssues/Application/Validators/InventoryIssueValidators.cs
@@ -1,0 +1,37 @@
+using FluentValidation;
+using IMS.Modular.Modules.InventoryIssues.Application.Commands;
+
+namespace IMS.Modular.Modules.InventoryIssues.Application.Validators;
+
+public class CreateInventoryIssueValidator : AbstractValidator<CreateInventoryIssueCommand>
+{
+    public CreateInventoryIssueValidator()
+    {
+        RuleFor(x => x.Title).NotEmpty().MaximumLength(300);
+        RuleFor(x => x.Description).NotEmpty().MaximumLength(4000);
+        RuleFor(x => x.ReporterId).NotEmpty();
+        RuleFor(x => x.AffectedQuantity).GreaterThan(0).When(x => x.AffectedQuantity.HasValue);
+        RuleFor(x => x.EstimatedLoss).GreaterThanOrEqualTo(0).When(x => x.EstimatedLoss.HasValue);
+        RuleFor(x => x.DueDate).GreaterThan(DateTime.UtcNow).When(x => x.DueDate.HasValue);
+    }
+}
+
+public class UpdateInventoryIssueValidator : AbstractValidator<UpdateInventoryIssueCommand>
+{
+    public UpdateInventoryIssueValidator()
+    {
+        RuleFor(x => x.Title).NotEmpty().MaximumLength(300);
+        RuleFor(x => x.Description).NotEmpty().MaximumLength(4000);
+        RuleFor(x => x.AffectedQuantity).GreaterThan(0).When(x => x.AffectedQuantity.HasValue);
+        RuleFor(x => x.EstimatedLoss).GreaterThanOrEqualTo(0).When(x => x.EstimatedLoss.HasValue);
+    }
+}
+
+public class AssignInventoryIssueValidator : AbstractValidator<AssignInventoryIssueCommand>
+{
+    public AssignInventoryIssueValidator()
+    {
+        RuleFor(x => x.AssigneeId).NotEmpty();
+        RuleFor(x => x.UserId).NotEmpty();
+    }
+}

--- a/src/Modules/InventoryIssues/Domain/Entities/InventoryIssue.cs
+++ b/src/Modules/InventoryIssues/Domain/Entities/InventoryIssue.cs
@@ -1,0 +1,129 @@
+using IMS.Modular.Modules.InventoryIssues.Domain.Enums;
+using IMS.Modular.Modules.InventoryIssues.Domain.Events;
+using IMS.Modular.Shared.Domain;
+
+namespace IMS.Modular.Modules.InventoryIssues.Domain.Entities;
+
+/// <summary>
+/// InventoryIssue — Aggregate Root for inventory-specific problem tracking.
+/// Lifecycle: Open → InProgress → Resolved/Closed → Reopened
+/// </summary>
+public class InventoryIssue : BaseEntity
+{
+    public string Title { get; private set; } = null!;
+    public string Description { get; private set; } = null!;
+    public InventoryIssueType Type { get; private set; }
+    public InventoryIssuePriority Priority { get; private set; }
+    public InventoryIssueStatus Status { get; private set; }
+
+    public Guid? ProductId { get; private set; }
+    public Guid? LocationId { get; private set; }
+    public Guid ReporterId { get; private set; }
+    public Guid? AssigneeId { get; private set; }
+
+    public int? AffectedQuantity { get; private set; }
+    public decimal? EstimatedLoss { get; private set; }
+    public DateTime? DueDate { get; private set; }
+    public DateTime? ResolvedAt { get; private set; }
+    public string? ResolutionNotes { get; private set; }
+
+    private InventoryIssue() { }
+
+    public InventoryIssue(
+        string title,
+        string description,
+        InventoryIssueType type,
+        InventoryIssuePriority priority,
+        Guid reporterId,
+        Guid? productId = null,
+        Guid? locationId = null,
+        int? affectedQuantity = null,
+        decimal? estimatedLoss = null,
+        DateTime? dueDate = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(title);
+        ArgumentException.ThrowIfNullOrWhiteSpace(description);
+
+        Title = title;
+        Description = description;
+        Type = type;
+        Priority = priority;
+        Status = InventoryIssueStatus.Open;
+        ReporterId = reporterId;
+        ProductId = productId;
+        LocationId = locationId;
+        AffectedQuantity = affectedQuantity;
+        EstimatedLoss = estimatedLoss;
+        DueDate = dueDate;
+
+        AddDomainEvent(new InventoryIssueCreatedEvent(Id, type, priority, reporterId));
+    }
+
+    public void Update(
+        string title,
+        string description,
+        InventoryIssueType type,
+        InventoryIssuePriority priority,
+        Guid? productId,
+        Guid? locationId,
+        int? affectedQuantity,
+        decimal? estimatedLoss,
+        DateTime? dueDate)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(title);
+        Title = title;
+        Description = description;
+        Type = type;
+        Priority = priority;
+        ProductId = productId;
+        LocationId = locationId;
+        AffectedQuantity = affectedQuantity;
+        EstimatedLoss = estimatedLoss;
+        DueDate = dueDate;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    public void Assign(Guid assigneeId, Guid userId)
+    {
+        var old = AssigneeId;
+        AssigneeId = assigneeId;
+        if (Status == InventoryIssueStatus.Open)
+            Status = InventoryIssueStatus.InProgress;
+        UpdatedAt = DateTime.UtcNow;
+        AddDomainEvent(new InventoryIssueAssignedEvent(Id, old, assigneeId, userId));
+    }
+
+    public void Resolve(string? resolutionNotes, Guid userId)
+    {
+        Status = InventoryIssueStatus.Resolved;
+        ResolutionNotes = resolutionNotes;
+        ResolvedAt = DateTime.UtcNow;
+        UpdatedAt = DateTime.UtcNow;
+        AddDomainEvent(new InventoryIssueStatusChangedEvent(Id, InventoryIssueStatus.InProgress, InventoryIssueStatus.Resolved, userId));
+        AddDomainEvent(new InventoryIssueResolvedEvent(Id, userId, CreatedAt));
+    }
+
+    public void Close(Guid userId)
+    {
+        var old = Status;
+        Status = InventoryIssueStatus.Closed;
+        UpdatedAt = DateTime.UtcNow;
+        AddDomainEvent(new InventoryIssueStatusChangedEvent(Id, old, InventoryIssueStatus.Closed, userId));
+    }
+
+    public void Reopen(Guid userId)
+    {
+        var old = Status;
+        Status = InventoryIssueStatus.Reopened;
+        ResolvedAt = null;
+        ResolutionNotes = null;
+        UpdatedAt = DateTime.UtcNow;
+        AddDomainEvent(new InventoryIssueStatusChangedEvent(Id, old, InventoryIssueStatus.Reopened, userId));
+    }
+
+    public void UpdatePriority(InventoryIssuePriority priority)
+    {
+        Priority = priority;
+        UpdatedAt = DateTime.UtcNow;
+    }
+}

--- a/src/Modules/InventoryIssues/Domain/Enums/InventoryIssueEnums.cs
+++ b/src/Modules/InventoryIssues/Domain/Enums/InventoryIssueEnums.cs
@@ -1,0 +1,34 @@
+namespace IMS.Modular.Modules.InventoryIssues.Domain.Enums;
+
+public enum InventoryIssueStatus
+{
+    Open,
+    InProgress,
+    Resolved,
+    Closed,
+    Reopened
+}
+
+public enum InventoryIssuePriority
+{
+    Low,
+    Medium,
+    High,
+    Critical
+}
+
+public enum InventoryIssueType
+{
+    Damage,
+    Loss,
+    Discrepancy,
+    Expiry,
+    Quality,
+    Shortage,
+    Overflow,
+    Misplacement,
+    CountError,
+    SystemError,
+    SupplierIssue,
+    Other
+}

--- a/src/Modules/InventoryIssues/Domain/Events/InventoryIssueDomainEvents.cs
+++ b/src/Modules/InventoryIssues/Domain/Events/InventoryIssueDomainEvents.cs
@@ -1,0 +1,39 @@
+using IMS.Modular.Modules.InventoryIssues.Domain.Enums;
+using IMS.Modular.Shared.Domain;
+
+namespace IMS.Modular.Modules.InventoryIssues.Domain.Events;
+
+public sealed class InventoryIssueCreatedEvent(
+    Guid issueId, InventoryIssueType type, InventoryIssuePriority priority, Guid reporterId) : DomainEventBase
+{
+    public Guid IssueId { get; } = issueId;
+    public InventoryIssueType Type { get; } = type;
+    public InventoryIssuePriority Priority { get; } = priority;
+    public Guid ReporterId { get; } = reporterId;
+}
+
+public sealed class InventoryIssueAssignedEvent(
+    Guid issueId, Guid? oldAssigneeId, Guid newAssigneeId, Guid userId) : DomainEventBase
+{
+    public Guid IssueId { get; } = issueId;
+    public Guid? OldAssigneeId { get; } = oldAssigneeId;
+    public Guid NewAssigneeId { get; } = newAssigneeId;
+    public Guid UserId { get; } = userId;
+}
+
+public sealed class InventoryIssueStatusChangedEvent(
+    Guid issueId, InventoryIssueStatus oldStatus, InventoryIssueStatus newStatus, Guid userId) : DomainEventBase
+{
+    public Guid IssueId { get; } = issueId;
+    public InventoryIssueStatus OldStatus { get; } = oldStatus;
+    public InventoryIssueStatus NewStatus { get; } = newStatus;
+    public Guid UserId { get; } = userId;
+}
+
+public sealed class InventoryIssueResolvedEvent(
+    Guid issueId, Guid userId, DateTime createdAt) : DomainEventBase
+{
+    public Guid IssueId { get; } = issueId;
+    public Guid UserId { get; } = userId;
+    public DateTime CreatedAt { get; } = createdAt;
+}

--- a/src/Modules/InventoryIssues/Infrastructure/InventoryIssuesDbContext.cs
+++ b/src/Modules/InventoryIssues/Infrastructure/InventoryIssuesDbContext.cs
@@ -1,0 +1,64 @@
+using IMS.Modular.Modules.InventoryIssues.Domain.Entities;
+using IMS.Modular.Shared.Domain;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace IMS.Modular.Modules.InventoryIssues.Infrastructure;
+
+public class InventoryIssuesDbContext(DbContextOptions<InventoryIssuesDbContext> options, IMediator mediator)
+    : DbContext(options)
+{
+    public DbSet<InventoryIssue> InventoryIssues => Set<InventoryIssue>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<InventoryIssue>(entity =>
+        {
+            entity.ToTable("InventoryIssues");
+            entity.HasKey(e => e.Id);
+
+            entity.Property(e => e.Title).IsRequired().HasMaxLength(300);
+            entity.Property(e => e.Description).IsRequired().HasMaxLength(4000);
+            entity.Property(e => e.Type).HasConversion<string>().HasMaxLength(30);
+            entity.Property(e => e.Priority).HasConversion<string>().HasMaxLength(20);
+            entity.Property(e => e.Status).HasConversion<string>().HasMaxLength(20);
+            entity.Property(e => e.ResolutionNotes).HasMaxLength(2000);
+            entity.Property(e => e.EstimatedLoss).HasPrecision(18, 2);
+
+            entity.HasIndex(e => e.Status);
+            entity.HasIndex(e => e.Priority);
+            entity.HasIndex(e => e.Type);
+            entity.HasIndex(e => e.ProductId);
+            entity.HasIndex(e => e.LocationId);
+            entity.HasIndex(e => e.ReporterId);
+            entity.HasIndex(e => e.AssigneeId);
+            entity.HasIndex(e => e.DueDate);
+            entity.HasIndex(e => e.CreatedAt);
+
+            entity.Ignore(e => e.DomainEvents);
+        });
+    }
+
+    public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        var domainEntities = ChangeTracker
+            .Entries<BaseEntity>()
+            .Where(e => e.Entity.DomainEvents.Any())
+            .ToList();
+
+        var domainEvents = domainEntities
+            .SelectMany(e => e.Entity.DomainEvents)
+            .ToList();
+
+        var result = await base.SaveChangesAsync(cancellationToken);
+
+        domainEntities.ForEach(e => e.Entity.ClearDomainEvents());
+
+        foreach (var domainEvent in domainEvents)
+            await mediator.Publish(domainEvent, cancellationToken);
+
+        return result;
+    }
+}

--- a/src/Modules/InventoryIssues/Infrastructure/InventoryIssuesRepositories.cs
+++ b/src/Modules/InventoryIssues/Infrastructure/InventoryIssuesRepositories.cs
@@ -1,0 +1,266 @@
+using System.Data;
+using Dapper;
+using IMS.Modular.Modules.InventoryIssues.Domain.Entities;
+using IMS.Modular.Modules.InventoryIssues.Domain.Enums;
+using IMS.Modular.Shared.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace IMS.Modular.Modules.InventoryIssues.Infrastructure;
+
+// ── EF Core Write Repository ─────────────────────────────────────────────
+
+public interface IInventoryIssueRepository
+{
+    Task<InventoryIssue?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task AddAsync(InventoryIssue issue, CancellationToken ct = default);
+    Task UpdateAsync(InventoryIssue issue, CancellationToken ct = default);
+    Task DeleteAsync(InventoryIssue issue, CancellationToken ct = default);
+}
+
+public class InventoryIssueRepository(InventoryIssuesDbContext db) : IInventoryIssueRepository
+{
+    public Task<InventoryIssue?> GetByIdAsync(Guid id, CancellationToken ct = default)
+        => db.InventoryIssues.FirstOrDefaultAsync(x => x.Id == id, ct);
+
+    public async Task AddAsync(InventoryIssue issue, CancellationToken ct = default)
+    {
+        db.InventoryIssues.Add(issue);
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task UpdateAsync(InventoryIssue issue, CancellationToken ct = default)
+    {
+        db.InventoryIssues.Update(issue);
+        await db.SaveChangesAsync(ct);
+    }
+
+    public async Task DeleteAsync(InventoryIssue issue, CancellationToken ct = default)
+    {
+        db.InventoryIssues.Remove(issue);
+        await db.SaveChangesAsync(ct);
+    }
+}
+
+// ── Dapper Read Repository ───────────────────────────────────────────────
+
+file static class GH
+{
+    internal static string Up(Guid id) => id.ToString().ToUpperInvariant();
+    internal static string? Up(Guid? id) => id.HasValue ? id.Value.ToString().ToUpperInvariant() : null;
+}
+
+public interface IInventoryIssueReadRepository
+{
+    Task<InventoryIssueReadDto?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task<PagedResult<InventoryIssueSummaryDto>> GetPagedAsync(
+        int page, int pageSize,
+        InventoryIssueStatus? status = null,
+        InventoryIssuePriority? priority = null,
+        InventoryIssueType? type = null,
+        Guid? productId = null,
+        Guid? locationId = null,
+        Guid? reporterId = null,
+        Guid? assigneeId = null,
+        string? search = null,
+        CancellationToken ct = default);
+    Task<PagedResult<InventoryIssueSummaryDto>> GetOverdueAsync(int page, int pageSize, CancellationToken ct = default);
+    Task<PagedResult<InventoryIssueSummaryDto>> GetHighPriorityAsync(int page, int pageSize, CancellationToken ct = default);
+    Task<InventoryIssueStatsDto> GetStatisticsAsync(CancellationToken ct = default);
+}
+
+public class InventoryIssueReadRepository(IDbConnection connection) : IInventoryIssueReadRepository
+{
+    public async Task<InventoryIssueReadDto?> GetByIdAsync(Guid id, CancellationToken ct = default)
+    {
+        const string sql = """
+            SELECT Id, Title, Description, Type, Priority, Status,
+                   ProductId, LocationId, ReporterId, AssigneeId,
+                   AffectedQuantity, EstimatedLoss, DueDate, ResolvedAt,
+                   ResolutionNotes, CreatedAt, UpdatedAt
+            FROM InventoryIssues
+            WHERE UPPER(Id) = @Id
+            """;
+        return await connection.QuerySingleOrDefaultAsync<InventoryIssueReadDto>(sql, new { Id = GH.Up(id) });
+    }
+
+    public async Task<PagedResult<InventoryIssueSummaryDto>> GetPagedAsync(
+        int page, int pageSize,
+        InventoryIssueStatus? status = null,
+        InventoryIssuePriority? priority = null,
+        InventoryIssueType? type = null,
+        Guid? productId = null,
+        Guid? locationId = null,
+        Guid? reporterId = null,
+        Guid? assigneeId = null,
+        string? search = null,
+        CancellationToken ct = default)
+    {
+        var where = new List<string>();
+        var p = new DynamicParameters();
+
+        if (status.HasValue)  { where.Add("Status = @Status");         p.Add("Status",     status.Value.ToString()); }
+        if (priority.HasValue){ where.Add("Priority = @Priority");      p.Add("Priority",   priority.Value.ToString()); }
+        if (type.HasValue)    { where.Add("Type = @Type");              p.Add("Type",       type.Value.ToString()); }
+        if (productId.HasValue) { where.Add("UPPER(ProductId) = @ProductId"); p.Add("ProductId", GH.Up(productId)); }
+        if (locationId.HasValue){ where.Add("UPPER(LocationId) = @LocationId"); p.Add("LocationId", GH.Up(locationId)); }
+        if (reporterId.HasValue){ where.Add("UPPER(ReporterId) = @ReporterId"); p.Add("ReporterId", GH.Up(reporterId)); }
+        if (assigneeId.HasValue){ where.Add("UPPER(AssigneeId) = @AssigneeId"); p.Add("AssigneeId", GH.Up(assigneeId)); }
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            where.Add("(Title LIKE @Search OR Description LIKE @Search)");
+            p.Add("Search", $"%{search}%");
+        }
+
+        var whereClause = where.Count > 0 ? "WHERE " + string.Join(" AND ", where) : "";
+        var countSql = $"SELECT COUNT(*) FROM InventoryIssues {whereClause}";
+        var dataSql = $"""
+            SELECT Id, Title, Type, Priority, Status, ProductId, LocationId,
+                   ReporterId, AssigneeId, AffectedQuantity, DueDate, CreatedAt, UpdatedAt
+            FROM InventoryIssues {whereClause}
+            ORDER BY CreatedAt DESC
+            LIMIT @PageSize OFFSET @Offset
+            """;
+
+        p.Add("PageSize", pageSize);
+        p.Add("Offset", (page - 1) * pageSize);
+
+        var total = await connection.ExecuteScalarAsync<int>(countSql, p);
+        var items = (await connection.QueryAsync<InventoryIssueSummaryDto>(dataSql, p)).AsList();
+        return new PagedResult<InventoryIssueSummaryDto>(items, total, page, pageSize);
+    }
+
+    public async Task<PagedResult<InventoryIssueSummaryDto>> GetOverdueAsync(int page, int pageSize, CancellationToken ct = default)
+    {
+        var p = new DynamicParameters();
+        p.Add("Now", DateTime.UtcNow.ToString("o"));
+        p.Add("PageSize", pageSize);
+        p.Add("Offset", (page - 1) * pageSize);
+
+        const string countSql = "SELECT COUNT(*) FROM InventoryIssues WHERE DueDate < @Now AND Status NOT IN ('Resolved','Closed')";
+        const string dataSql = """
+            SELECT Id, Title, Type, Priority, Status, ProductId, LocationId,
+                   ReporterId, AssigneeId, AffectedQuantity, DueDate, CreatedAt, UpdatedAt
+            FROM InventoryIssues
+            WHERE DueDate < @Now AND Status NOT IN ('Resolved','Closed')
+            ORDER BY DueDate ASC
+            LIMIT @PageSize OFFSET @Offset
+            """;
+
+        var total = await connection.ExecuteScalarAsync<int>(countSql, p);
+        var items = (await connection.QueryAsync<InventoryIssueSummaryDto>(dataSql, p)).AsList();
+        return new PagedResult<InventoryIssueSummaryDto>(items, total, page, pageSize);
+    }
+
+    public async Task<PagedResult<InventoryIssueSummaryDto>> GetHighPriorityAsync(int page, int pageSize, CancellationToken ct = default)
+    {
+        var p = new DynamicParameters();
+        p.Add("PageSize", pageSize);
+        p.Add("Offset", (page - 1) * pageSize);
+
+        const string countSql = "SELECT COUNT(*) FROM InventoryIssues WHERE Priority IN ('High','Critical') AND Status NOT IN ('Resolved','Closed')";
+        const string dataSql = """
+            SELECT Id, Title, Type, Priority, Status, ProductId, LocationId,
+                   ReporterId, AssigneeId, AffectedQuantity, DueDate, CreatedAt, UpdatedAt
+            FROM InventoryIssues
+            WHERE Priority IN ('High','Critical') AND Status NOT IN ('Resolved','Closed')
+            ORDER BY Priority DESC, CreatedAt DESC
+            LIMIT @PageSize OFFSET @Offset
+            """;
+
+        var total = await connection.ExecuteScalarAsync<int>(countSql, p);
+        var items = (await connection.QueryAsync<InventoryIssueSummaryDto>(dataSql, p)).AsList();
+        return new PagedResult<InventoryIssueSummaryDto>(items, total, page, pageSize);
+    }
+
+    public async Task<InventoryIssueStatsDto> GetStatisticsAsync(CancellationToken ct = default)
+    {
+        const string sql = """
+            SELECT
+                COUNT(*) AS Total,
+                SUM(CASE WHEN Status = 'Open' THEN 1 ELSE 0 END) AS Open,
+                SUM(CASE WHEN Status = 'InProgress' THEN 1 ELSE 0 END) AS InProgress,
+                SUM(CASE WHEN Status = 'Resolved' THEN 1 ELSE 0 END) AS Resolved,
+                SUM(CASE WHEN Status = 'Closed' THEN 1 ELSE 0 END) AS Closed,
+                SUM(CASE WHEN Status = 'Reopened' THEN 1 ELSE 0 END) AS Reopened,
+                SUM(CASE WHEN Priority = 'Low' THEN 1 ELSE 0 END) AS LowPriority,
+                SUM(CASE WHEN Priority = 'Medium' THEN 1 ELSE 0 END) AS MediumPriority,
+                SUM(CASE WHEN Priority = 'High' THEN 1 ELSE 0 END) AS HighPriority,
+                SUM(CASE WHEN Priority = 'Critical' THEN 1 ELSE 0 END) AS CriticalPriority,
+                SUM(CASE WHEN DueDate < CURRENT_TIMESTAMP AND Status NOT IN ('Resolved','Closed') THEN 1 ELSE 0 END) AS Overdue
+            FROM InventoryIssues
+            """;
+
+        var row = await connection.QuerySingleAsync<dynamic>(sql);
+
+        var byType = (await connection.QueryAsync<(string Type, int Count)>(
+            "SELECT Type, COUNT(*) AS Count FROM InventoryIssues GROUP BY Type")).AsList();
+
+        return new InventoryIssueStatsDto(
+            (int)(row.Total ?? 0),
+            (int)(row.Open ?? 0),
+            (int)(row.InProgress ?? 0),
+            (int)(row.Resolved ?? 0),
+            (int)(row.Closed ?? 0),
+            (int)(row.Reopened ?? 0),
+            (int)(row.LowPriority ?? 0),
+            (int)(row.MediumPriority ?? 0),
+            (int)(row.HighPriority ?? 0),
+            (int)(row.CriticalPriority ?? 0),
+            (int)(row.Overdue ?? 0),
+            byType.ToDictionary(x => x.Type, x => x.Count));
+    }
+}
+
+// ── Read DTOs ─────────────────────────────────────────────────────────────
+
+public sealed class InventoryIssueReadDto
+{
+    public Guid Id { get; set; }
+    public string Title { get; set; } = null!;
+    public string Description { get; set; } = null!;
+    public string Type { get; set; } = null!;
+    public string Priority { get; set; } = null!;
+    public string Status { get; set; } = null!;
+    public Guid? ProductId { get; set; }
+    public Guid? LocationId { get; set; }
+    public Guid ReporterId { get; set; }
+    public Guid? AssigneeId { get; set; }
+    public int? AffectedQuantity { get; set; }
+    public decimal? EstimatedLoss { get; set; }
+    public DateTime? DueDate { get; set; }
+    public DateTime? ResolvedAt { get; set; }
+    public string? ResolutionNotes { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+}
+
+public sealed class InventoryIssueSummaryDto
+{
+    public Guid Id { get; set; }
+    public string Title { get; set; } = null!;
+    public string Type { get; set; } = null!;
+    public string Priority { get; set; } = null!;
+    public string Status { get; set; } = null!;
+    public Guid? ProductId { get; set; }
+    public Guid? LocationId { get; set; }
+    public Guid ReporterId { get; set; }
+    public Guid? AssigneeId { get; set; }
+    public int? AffectedQuantity { get; set; }
+    public DateTime? DueDate { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+}
+
+public record InventoryIssueStatsDto(
+    int Total,
+    int Open,
+    int InProgress,
+    int Resolved,
+    int Closed,
+    int Reopened,
+    int LowPriority,
+    int MediumPriority,
+    int HighPriority,
+    int CriticalPriority,
+    int Overdue,
+    Dictionary<string, int> ByType);

--- a/src/Modules/InventoryIssues/InventoryIssuesModuleExtensions.cs
+++ b/src/Modules/InventoryIssues/InventoryIssuesModuleExtensions.cs
@@ -1,0 +1,48 @@
+using System.Data;
+using IMS.Modular.Modules.InventoryIssues.Infrastructure;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace IMS.Modular.Modules.InventoryIssues;
+
+public static class InventoryIssuesModuleExtensions
+{
+    public static IServiceCollection AddInventoryIssuesModule(this IServiceCollection services, IConfiguration configuration)
+    {
+        var connectionString = configuration.GetConnectionString("DefaultConnection")!;
+
+        services.AddDbContext<InventoryIssuesDbContext>(options =>
+            options.UseSqlite(connectionString,
+                b => b.MigrationsAssembly(typeof(InventoryIssuesDbContext).Assembly.FullName)));
+
+        services.AddScoped<IInventoryIssueRepository, InventoryIssueRepository>();
+
+        services.AddScoped<IDbConnection>(_ => new SqliteConnection(connectionString));
+        services.AddScoped<IInventoryIssueReadRepository, InventoryIssueReadRepository>();
+
+        return services;
+    }
+
+    public static async Task InitializeInventoryIssuesModuleAsync(this IServiceProvider services)
+    {
+        using var scope = services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<InventoryIssuesDbContext>();
+
+        var sql = db.Database.GenerateCreateScript();
+
+        foreach (var statement in sql.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+        {
+            var trimmed = statement.Trim();
+            if (string.IsNullOrEmpty(trimmed)) continue;
+
+            try
+            {
+                await db.Database.ExecuteSqlRawAsync(trimmed);
+            }
+            catch (SqliteException ex) when (ex.SqliteErrorCode == 1 && ex.Message.Contains("already exists"))
+            {
+                // Safe to ignore — table already exists
+            }
+        }
+    }
+}

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,8 +1,12 @@
 using FluentValidation;
+using IMS.Modular.Modules.Analytics;
+using IMS.Modular.Modules.Analytics.Api;
 using IMS.Modular.Modules.Auth;
 using IMS.Modular.Modules.Auth.Api;
 using IMS.Modular.Modules.Inventory;
 using IMS.Modular.Modules.Inventory.Api;
+using IMS.Modular.Modules.InventoryIssues;
+using IMS.Modular.Modules.InventoryIssues.Api;
 using IMS.Modular.Modules.Issues;
 using IMS.Modular.Modules.Issues.Api;
 using IMS.Modular.Shared.Abstractions;
@@ -114,6 +118,8 @@ builder.Services.AddCors(options =>
 builder.Services.AddAuthModule(builder.Configuration);
 builder.Services.AddIssuesModule(builder.Configuration);
 builder.Services.AddInventoryModule(builder.Configuration);
+builder.Services.AddInventoryIssuesModule(builder.Configuration);
+builder.Services.AddAnalyticsModule(builder.Configuration);
 
 // ============================================================
 // HEALTH CHECKS (US-007)
@@ -197,8 +203,7 @@ app.MapGet("/api/status", () => Results.Ok(new
 {
     Status = "Running",
     Version = "1.0.0",
-    Environment = app.Environment.EnvironmentName,
-    Modules = new[] { "Auth", "Issues", "Inventory" },
+    Environment = app.Environment.EnvironmentName,        Modules = new[] { "Auth", "Issues", "Inventory", "InventoryIssues", "Analytics" },
     Timestamp = DateTime.UtcNow
 }))
 .WithName("GetStatus")
@@ -212,6 +217,8 @@ app.MapGet("/api/status", () => Results.Ok(new
 AuthModule.Map(app);
 IssuesModule.Map(app);
 InventoryModule.Map(app);
+InventoryIssuesModule.Map(app);
+AnalyticsModule.Map(app);
 
 // ============================================================
 // DATABASE INITIALIZATION
@@ -220,6 +227,7 @@ InventoryModule.Map(app);
 await app.Services.InitializeAuthModuleAsync();
 await app.Services.InitializeIssuesModuleAsync();
 await app.Services.InitializeInventoryModuleAsync();
+await app.Services.InitializeInventoryIssuesModuleAsync();
 
 // ============================================================
 // RUN


### PR DESCRIPTION
## Summary

Implements **Phase 4 Analytics** covering US-014 through US-018.

---

## User Stories

| Story | Description | Endpoints |
|-------|-------------|-----------|
| US-014 | Inventory Issues — full lifecycle tracking | 13 endpoints `/api/inventory-issues` |
| US-015 | Issue Analytics — summary, trends, resolution time | 8 endpoints `/api/analytics/issues` |
| US-016 | User Workload Analytics | 3 endpoints `/api/analytics/users` |
| US-017 | Dashboard & Export (JSON/CSV) | 3 endpoints `/api/analytics` |
| US-018 | Inventory Analytics — value, trends, turnover | 10 endpoints `/api/inventory/analytics` |

---

## US-014: Inventory Issues

### Domain
- `InventoryIssue` aggregate root — lifecycle: Open → InProgress → Resolved → Closed → Reopened
- `InventoryIssueType` (12 types): Damage, Loss, Discrepancy, Expiry, Quality, Shortage, etc.
- `InventoryIssuePriority`: Low, Medium, High, Critical
- Domain Events: Created, Assigned, StatusChanged, Resolved

### Infrastructure
- EF Core: `InventoryIssuesDbContext` with Fluent API, domain event dispatch, 9 indexes
- Dapper: Paged/filtered list, overdue view, high-priority view, statistics

### Application
- Commands: Create, Update, Assign, Resolve, Close, Reopen, Delete
- Queries: GetById, GetPaged, GetOverdue, GetHighPriority, GetStatistics
- FluentValidation on all commands

### API Endpoints `/api/inventory-issues`
```
GET    /                  list (filter: status, priority, type, product, location, reporter, assignee, search)
GET    /{id}              get by ID
GET    /overdue           overdue issues
GET    /high-priority     high-priority open issues
GET    /statistics        counts by status, priority, type
POST   /                  create
PUT    /{id}              update
DELETE /{id}              delete (204)
PATCH  /{id}/assign       assign to user
PATCH  /{id}/resolve      resolve with notes
PATCH  /{id}/close        close
PATCH  /{id}/reopen       reopen
```

---

## US-015: Issue Analytics `/api/analytics/issues`
- Summary (total, open, in-progress, resolved, closed, overdue, due-today)
- Trends over time (configurable days)
- Avg/Min/Max resolution time by priority
- Stats by status, priority, assignee
- Auto-assign suggestion (lowest load + best resolution time)

---

## US-016: User Workload `/api/analytics/users`
- All users workload summary
- Individual user workload detail (avg resolution hours, completion rate)
- User statistics

---

## US-017: Dashboard & Export `/api/analytics`
- `GET /dashboard` — combined KPIs: issue summary + inventory summary + recent trends + top 5 assignees
- `GET /export` — quick export (query params: format, module, from, to)
- `POST /export` — parametrized export (JSON/CSV)

---

## US-018: Inventory Analytics `/api/inventory/analytics`
- Value (total, by category, by location)
- Summary (total, active, discontinued, low/out-of-stock, overstock, total value)
- Stock status distribution
- Stock trends (configurable days, based on StockMovements)
- Category distribution
- Turnover rate (top N products)
- Expiring products report (configurable days-ahead window)
- Location capacity utilization
- Supplier performance (total products, purchases, purchase value)
- Top products (by value, movement, or stock)

---

## Technical
- All analytics queries: Dapper + SQLite UPPER() GUID handling
- Output caching (10-min TTL) on all read endpoints via `ICacheable`
- `InventoryIssuesModuleExtensions`: DI + SQLite table auto-creation
- `AnalyticsModuleExtensions`: DI (read-only, shared SQLite connection)
- All 5 modules listed in `/api/status`

## Verification
✅ `dotnet build` — 0 errors, 0 warnings  
✅ App starts, tables created (`InventoryIssues` + indexes)  
✅ `/api/status` → modules: Auth, Issues, Inventory, InventoryIssues, Analytics  
✅ `/health` → Healthy