### PR TITLE
feat(US-035): CI/CD Frontend — Build, Lint, Type-check e Docker

### DIFF
--- a/.env.frontend.example
+++ b/.env.frontend.example
@@ -1,0 +1,32 @@
+# =============================================================
+# IMS Frontend — Variáveis de Ambiente
+# =============================================================
+# Copie este arquivo para .env.local (desenvolvimento local)
+# ou configure as variáveis no servidor/CI.
+#
+# NUNCA commite o arquivo .env.local com valores reais.
+# =============================================================
+
+# ── Next.js Auth ──────────────────────────────────────────────
+# Segredo para assinar os cookies de sessão.
+# Gere com: openssl rand -base64 32
+NEXTAUTH_SECRET=your-secret-here-min-32-chars
+
+# URL base do frontend (sem trailing slash)
+NEXTAUTH_URL=http://localhost:3000
+
+# ── API / BFF ─────────────────────────────────────────────────
+# URL do backend .NET (server-side only — não exposta ao browser)
+IMS_API_URL=http://localhost:5049
+
+# URL pública da API (exposta ao browser via NEXT_PUBLIC_)
+NEXT_PUBLIC_API_URL=http://localhost:5049
+
+# ── Blazor ────────────────────────────────────────────────────
+# Caminho público dos artefatos Blazor WASM (relativo a /public)
+# Não altere sem rodar scripts/build-blazor.sh antes
+NEXT_PUBLIC_BLAZOR_PATH=/_blazor
+
+# ── App ───────────────────────────────────────────────────────
+# URL pública do frontend
+NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -1,0 +1,223 @@
+# =============================================================
+# US-035: CI Frontend — Build, Lint, Type-check
+# =============================================================
+# Jobs:
+#   1. build-blazor   — dotnet publish Blazor WASM + upload artifact
+#   2. lint-typecheck — ESLint + tsc --noEmit (sem artefato Blazor)
+#   3. build-nextjs   — npm run build (depende de build-blazor)
+#   4. docker-frontend — build Docker image do frontend (main only)
+# =============================================================
+
+name: CI Frontend — Build & Lint
+
+on:
+  push:
+    branches: ["main", "feat/**", "fix/**", "chore/**"]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/ci-frontend.yml"
+      - "Dockerfile.frontend"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "frontend/**"
+      - ".github/workflows/ci-frontend.yml"
+      - "Dockerfile.frontend"
+  workflow_dispatch:
+
+env:
+  DOTNET_VERSION: "9.0.x"
+  NODE_VERSION: "20"
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}-frontend
+
+# ─────────────────────────────────────────────────────────────
+# Job 1: Publish Blazor WASM
+# ─────────────────────────────────────────────────────────────
+jobs:
+  build-blazor:
+    name: "Blazor WASM — dotnet publish"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET ${{ env.DOTNET_VERSION }}
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Cache NuGet
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-blazor-${{ hashFiles('frontend/apps/blazor-modules/**/*.csproj') }}
+          restore-keys: ${{ runner.os }}-nuget-blazor-
+
+      - name: Publish Blazor WASM (Release)
+        run: |
+          dotnet publish frontend/apps/blazor-modules \
+            -c Release \
+            -o frontend/apps/blazor-modules/publish \
+            --nologo
+
+      - name: Upload Blazor wwwroot
+        uses: actions/upload-artifact@v4
+        with:
+          name: blazor-wwwroot
+          path: frontend/apps/blazor-modules/publish/wwwroot
+          retention-days: 1
+
+  # ─────────────────────────────────────────────────────────────
+  # Job 2: ESLint + TypeScript type-check (paralelo ao Blazor)
+  # ─────────────────────────────────────────────────────────────
+  lint-typecheck:
+    name: "Next.js — Lint & Type-check"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+          cache-dependency-path: frontend/apps/next-shell/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: frontend/apps/next-shell
+
+      - name: ESLint
+        run: npm run lint
+        working-directory: frontend/apps/next-shell
+
+      - name: TypeScript type-check
+        run: npm run typecheck
+        working-directory: frontend/apps/next-shell
+
+  # ─────────────────────────────────────────────────────────────
+  # Job 3: Next.js build (depende do Blazor)
+  # ─────────────────────────────────────────────────────────────
+  build-nextjs:
+    name: "Next.js — next build"
+    runs-on: ubuntu-latest
+    needs: [build-blazor, lint-typecheck]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+          cache-dependency-path: frontend/apps/next-shell/package-lock.json
+
+      - name: Download Blazor artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: blazor-wwwroot
+          path: frontend/apps/next-shell/public/_blazor
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: frontend/apps/next-shell
+
+      - name: Build Next.js (Release)
+        run: npm run build
+        working-directory: frontend/apps/next-shell
+        env:
+          NEXTAUTH_SECRET: ${{ secrets.NEXTAUTH_SECRET || 'ci-secret-placeholder-32-chars-min' }}
+          NEXTAUTH_URL: ${{ vars.NEXTAUTH_URL || 'http://localhost:3000' }}
+          NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL || 'http://localhost:5049' }}
+
+      - name: Upload Next.js build
+        uses: actions/upload-artifact@v4
+        with:
+          name: nextjs-build
+          path: |
+            frontend/apps/next-shell/.next/
+            frontend/apps/next-shell/public/
+          retention-days: 1
+
+      - name: Build summary
+        run: |
+          echo "### ✅ Frontend Build OK" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Artefato | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "|---|---|" >> $GITHUB_STEP_SUMMARY
+          echo "| Blazor WASM | ✅ |" >> $GITHUB_STEP_SUMMARY
+          echo "| Next.js | ✅ |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          BLAZOR_FILES=$(ls frontend/apps/next-shell/public/_blazor/_framework/ | wc -l | tr -d ' ')
+          echo "Blazor \`_framework/\`: **${BLAZOR_FILES} arquivos**" >> $GITHUB_STEP_SUMMARY
+
+  # ─────────────────────────────────────────────────────────────
+  # Job 4: Docker image do frontend (apenas no push para main)
+  # ─────────────────────────────────────────────────────────────
+  docker-frontend:
+    name: "Docker — Build & Push Frontend"
+    runs-on: ubuntu-latest
+    needs: build-nextjs
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download Blazor artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: blazor-wwwroot
+          path: frontend/apps/next-shell/public/_blazor
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=sha-,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.frontend
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            NEXTAUTH_SECRET=${{ secrets.NEXTAUTH_SECRET }}
+            NEXT_PUBLIC_API_URL=${{ vars.NEXT_PUBLIC_API_URL || 'http://localhost:5049' }}
+
+      - name: Image summary
+        run: |
+          echo "### 🐳 Docker Frontend Published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Image:** \`${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Tags:**" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          echo "${{ steps.meta.outputs.tags }}" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,85 @@
+# =============================================================
+# US-035: Dockerfile.frontend — IMS Frontend (Next.js + Blazor)
+# =============================================================
+# Stages:
+#   1. blazor-build  — dotnet publish Blazor WASM
+#   2. nextjs-deps   — npm ci (cache de dependências)
+#   3. nextjs-build  — npm run build com artefatos Blazor
+#   4. runner        — imagem final standalone com Node.js
+# =============================================================
+
+# ── 1. Blazor WASM publish ────────────────────────────────────
+FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS blazor-build
+
+WORKDIR /app
+
+COPY frontend/apps/blazor-modules/ ./frontend/apps/blazor-modules/
+
+RUN dotnet publish frontend/apps/blazor-modules \
+    -c Release \
+    -o /blazor-publish \
+    --nologo
+
+# ── 2. Next.js deps (cache layer) ────────────────────────────
+FROM node:20-alpine AS nextjs-deps
+
+WORKDIR /app
+
+COPY frontend/apps/next-shell/package.json frontend/apps/next-shell/package-lock.json ./
+
+RUN npm ci --prefer-offline
+
+# ── 3. Next.js build ─────────────────────────────────────────
+FROM node:20-alpine AS nextjs-build
+
+WORKDIR /app
+
+# Copy dependencies
+COPY --from=nextjs-deps /app/node_modules ./node_modules
+
+# Copy source
+COPY frontend/apps/next-shell/ .
+
+# Copy Blazor WASM artifacts into public/_blazor/
+COPY --from=blazor-build /blazor-publish/wwwroot ./public/_blazor/
+
+# Build args → env vars em build time
+ARG NEXTAUTH_SECRET
+ARG NEXTAUTH_URL=http://localhost:3000
+ARG NEXT_PUBLIC_API_URL=http://localhost:5049
+
+ENV NEXTAUTH_SECRET=${NEXTAUTH_SECRET}
+ENV NEXTAUTH_URL=${NEXTAUTH_URL}
+ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
+
+# Next.js standalone output
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN npm run build
+
+# ── 4. Runner — imagem final ──────────────────────────────────
+FROM node:20-alpine AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# Security: non-root user
+RUN addgroup -S ims && adduser -S ims -G ims
+
+# Copiar apenas o necessário do standalone build
+COPY --from=nextjs-build --chown=ims:ims /app/public ./public
+COPY --from=nextjs-build --chown=ims:ims /app/.next/standalone ./
+COPY --from=nextjs-build --chown=ims:ims /app/.next/static ./.next/static
+
+USER ims
+
+EXPOSE 3000
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
+    CMD wget -qO- http://localhost:3000/api/health || exit 1
+
+CMD ["node", "server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,41 @@ services:
       - ims-net
 
   # ─────────────────────────────────────────────────────────
+  # Frontend — Next.js + Blazor WASM
+  # ─────────────────────────────────────────────────────────
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend
+      args:
+        NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
+        NEXTAUTH_URL: ${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://app:8080}
+    image: ims-frontend:latest
+    container_name: ims-frontend
+    restart: unless-stopped
+    ports:
+      - "${FRONTEND_PORT:-3000}:3000"
+    environment:
+      NODE_ENV: production
+      NEXTAUTH_SECRET: ${NEXTAUTH_SECRET}
+      NEXTAUTH_URL: ${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
+      IMS_API_URL: http://app:8080
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8080}
+      NEXT_PUBLIC_APP_URL: ${NEXT_PUBLIC_APP_URL:-http://localhost:3000}
+    depends_on:
+      app:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 20s
+    networks:
+      - ims-net
+
+  # ─────────────────────────────────────────────────────────
   # PostgreSQL 16
   # ─────────────────────────────────────────────────────────
   postgres:

--- a/frontend/apps/next-shell/app/api/health/route.ts
+++ b/frontend/apps/next-shell/app/api/health/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+
+/**
+ * GET /api/health
+ * Endpoint de healthcheck para Docker e load balancer.
+ */
+export function GET() {
+  return NextResponse.json(
+    {
+      status: "ok",
+      service: "ims-frontend",
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 }
+  );
+}

--- a/frontend/apps/next-shell/next.config.ts
+++ b/frontend/apps/next-shell/next.config.ts
@@ -3,6 +3,8 @@ import type { NextConfig } from "next";
 const IMS_API_URL = process.env.IMS_API_URL ?? "http://localhost:5049";
 
 const nextConfig: NextConfig = {
+  // Habilita output standalone para Docker (copia apenas os arquivos necessários)
+  output: "standalone",
   async rewrites() {
     return [
       {

--- a/frontend/apps/next-shell/package.json
+++ b/frontend/apps/next-shell/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",


### PR DESCRIPTION
## O que essa PR faz

Implementa a US-035: pipeline CI/CD completo para o frontend (Next.js + Blazor WASM).

## Mudanças

### `.github/workflows/ci-frontend.yml`
Pipeline de 4 jobs acionado por mudanças em `frontend/**`:

| Job | O que faz | Depende de |
|---|---|---|
| `build-blazor` | `dotnet publish` Blazor WASM + upload artifact | — |
| `lint-typecheck` | ESLint + `tsc --noEmit` | — (paralelo) |
| `build-nextjs` | Baixa artifact Blazor → `npm run build` | `build-blazor` + `lint-typecheck` |
| `docker-frontend` | Build + push GHCR | `build-nextjs` (apenas push em main) |

### `Dockerfile.frontend`
Multi-stage otimizado:
- Stage `blazor-build`: `dotnet publish` Blazor WASM
- Stage `nextjs-deps`: `npm ci` (cache de dependências)
- Stage `nextjs-build`: `npm run build` com artefatos Blazor em `public/_blazor/`
- Stage `runner`: imagem final `node:20-alpine` com output standalone

### `docker-compose.yml`
Serviço `frontend` adicionado com `depends_on: app` e healthcheck em `/api/health`.

### Outros
- `next.config.ts`: `output: 'standalone'` para Docker
- `package.json`: script `typecheck` (`tsc --noEmit`)
- `app/api/health/route.ts`: endpoint de healthcheck
- `.env.frontend.example`: todas as variáveis documentadas

## Como testar localmente

```bash
# Build completo via Docker
docker compose build frontend
docker compose up frontend

# Ou manualmente
./scripts/build-blazor.sh
cd frontend/apps/next-shell
npm run lint && npm run typecheck && npm run build
```

Closes #45