### PR TITLE
feat(US-037): Auth Hardening — Refresh Token Automático e Logout Seguro

### DIFF
--- a/frontend/apps/next-shell/app/(auth)/login/page.tsx
+++ b/frontend/apps/next-shell/app/(auth)/login/page.tsx
@@ -19,7 +19,15 @@ function LoginForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const callbackUrl = searchParams.get("callbackUrl") ?? "/dashboard/issues";
+  const reason = searchParams.get("reason");
   const [showPassword, setShowPassword] = useState(false);
+
+  // Exibir toast de sessão expirada se redirecionado pelo api-client
+  useState(() => {
+    if (reason === "session_expired") {
+      toast.warning("Sua sessão expirou. Faça login novamente.");
+    }
+  });
 
   const {
     register,

--- a/frontend/apps/next-shell/app/(dashboard)/layout.tsx
+++ b/frontend/apps/next-shell/app/(dashboard)/layout.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 import { getSession } from "@/lib/auth";
 import { Sidebar } from "@/components/sidebar";
 import { BlazorHost } from "@/components/blazor-host";
+import { SessionSync } from "@/components/session-sync";
 
 export default async function DashboardLayout({
   children,
@@ -19,6 +20,8 @@ export default async function DashboardLayout({
       </main>
       {/* Blazor WASM runtime — carregado lazy uma única vez no layout */}
       <BlazorHost />
+      {/* Sincroniza logout entre abas via BroadcastChannel */}
+      <SessionSync />
     </div>
   );
 }

--- a/frontend/apps/next-shell/app/api/auth/logout/route.ts
+++ b/frontend/apps/next-shell/app/api/auth/logout/route.ts
@@ -1,11 +1,35 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 const AUTH_COOKIE = "ims_access_token";
 const REFRESH_COOKIE = "ims_refresh_token";
+const IMS_API = process.env.IMS_API_URL ?? "http://localhost:5049";
 
-export async function POST() {
+export async function POST(request: NextRequest) {
+  const refreshToken = request.cookies.get(REFRESH_COOKIE)?.value;
+
+  // Notificar backend para invalidar o refresh token (best-effort)
+  if (refreshToken) {
+    await fetch(`${IMS_API}/api/auth/logout`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ refreshToken }),
+    }).catch(() => {
+      // Ignorar erros — o cookie será removido de qualquer forma
+    });
+  }
+
   const response = NextResponse.json({ message: "Logged out" });
-  response.cookies.delete(AUTH_COOKIE);
-  response.cookies.delete(REFRESH_COOKIE);
+
+  // Expirar ambos os cookies
+  const expiredOpts = {
+    httpOnly: true,
+    path: "/",
+    sameSite: "strict" as const,
+    maxAge: 0,
+    secure: process.env.NODE_ENV === "production",
+  };
+  response.cookies.set(AUTH_COOKIE, "", expiredOpts);
+  response.cookies.set(REFRESH_COOKIE, "", expiredOpts);
+
   return response;
 }

--- a/frontend/apps/next-shell/components/session-sync.tsx
+++ b/frontend/apps/next-shell/components/session-sync.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { initSessionSync } from '@/lib/session-sync';
+
+/**
+ * SessionSync — monta o listener de BroadcastChannel para logout cross-tab.
+ * Deve ser colocado no layout do dashboard (client component leaf).
+ */
+export function SessionSync() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const cleanup = initSessionSync(() => {
+      router.push('/login?reason=session_expired');
+    });
+    return cleanup;
+  }, [router]);
+
+  return null;
+}

--- a/frontend/apps/next-shell/lib/api-client.ts
+++ b/frontend/apps/next-shell/lib/api-client.ts
@@ -1,0 +1,145 @@
+/**
+ * api-client.ts — US-037: Auth Hardening
+ *
+ * Fetch wrapper client-side com:
+ *  - Interceptor de 401: pausa a fila, faz refresh, reexecuta requests
+ *  - Mutex de refresh: garante que apenas 1 refresh ocorre por vez
+ *  - Redirect para /login se o refresh falhar
+ *  - Tipagem genérica de resposta
+ */
+
+type QueueEntry = {
+  resolve: (value: unknown) => void;
+  reject: (reason?: unknown) => void;
+};
+
+let isRefreshing = false;
+let failedQueue: QueueEntry[] = [];
+
+function processQueue(error: unknown) {
+  failedQueue.forEach((entry) => {
+    if (error) {
+      entry.reject(error);
+    } else {
+      entry.resolve(undefined);
+    }
+  });
+  failedQueue = [];
+}
+
+async function attemptRefresh(): Promise<boolean> {
+  try {
+    const res = await fetch("/api/auth/refresh", {
+      method: "POST",
+      credentials: "include",
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export interface ApiClientOptions extends RequestInit {
+  /** Se false, não tenta refresh em 401 (ex: na própria rota de login) */
+  skipRefresh?: boolean;
+}
+
+/**
+ * apiFetch — wrapper client-side que usa o BFF proxy.
+ * Ao receber 401, tenta refresh automático uma vez antes de redirecionar para /login.
+ * Requests paralelos são enfileirados e re-executados após o refresh.
+ *
+ * @example
+ * const data = await apiFetch<IssueDto[]>('/api/proxy/issues');
+ */
+export async function apiFetch<T = unknown>(
+  url: string,
+  options: ApiClientOptions = {}
+): Promise<T> {
+  const { skipRefresh = false, ...fetchOptions } = options;
+
+  const res = await fetch(url, {
+    ...fetchOptions,
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+      ...(fetchOptions.headers as Record<string, string>),
+    },
+  });
+
+  // Resposta OK
+  if (res.ok) {
+    if (res.status === 204) return undefined as T;
+    return res.json() as Promise<T>;
+  }
+
+  // Erros que não são 401 — lança imediatamente
+  if (res.status !== 401 || skipRefresh) {
+    const body = await res.text().catch(() => res.statusText);
+    throw new ApiError(res.status, body, url);
+  }
+
+  // ── 401: tentar refresh ──────────────────────────────────────────────────
+  if (isRefreshing) {
+    // Outro request já está fazendo refresh — enfileira e aguarda
+    return new Promise<T>((resolve, reject) => {
+      failedQueue.push({
+        resolve: () =>
+          apiFetch<T>(url, { ...options, skipRefresh: true })
+            .then(resolve)
+            .catch(reject),
+        reject,
+      });
+    });
+  }
+
+  isRefreshing = true;
+
+  const refreshed = await attemptRefresh();
+
+  isRefreshing = false;
+
+  if (!refreshed) {
+    processQueue(new ApiError(401, "Session expired", url));
+    // Broadcast logout para outras abas e redireciona
+    if (typeof window !== "undefined") {
+      try {
+        new BroadcastChannel("ims_session").postMessage({ type: "LOGOUT" });
+      } catch {
+        // BroadcastChannel não suportado em todos os ambientes
+      }
+      window.location.href = "/login?reason=session_expired";
+    }
+    throw new ApiError(401, "Session expired", url);
+  }
+
+  // Refresh bem-sucedido — processa a fila e reexecuta o request original
+  processQueue(null);
+
+  return apiFetch<T>(url, { ...options, skipRefresh: true });
+}
+
+// ── Classe de erro tipado ────────────────────────────────────────────────────
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly body: string,
+    public readonly url: string
+  ) {
+    super(`API ${status}: ${body} [${url}]`);
+    this.name = "ApiError";
+  }
+
+  get isUnauthorized() {
+    return this.status === 401;
+  }
+
+  get isNotFound() {
+    return this.status === 404;
+  }
+
+  get isServerError() {
+    return this.status >= 500;
+  }
+}

--- a/frontend/apps/next-shell/lib/session-sync.ts
+++ b/frontend/apps/next-shell/lib/session-sync.ts
@@ -1,0 +1,60 @@
+/**
+ * session-sync.ts — US-037
+ *
+ * Sincroniza eventos de sessão entre abas via BroadcastChannel.
+ * - Logout em uma aba → todas as outras são redirecionadas para /login
+ * - Session expired → todas redirecionam
+ */
+
+export const SESSION_CHANNEL = "ims_session";
+
+export type SessionMessage =
+  | { type: "LOGOUT" }
+  | { type: "SESSION_EXPIRED" }
+  | { type: "LOGIN" };
+
+/**
+ * Inicia o listener de sincronização de sessão.
+ * Deve ser chamado uma vez no lado cliente (ex: layout do dashboard).
+ * Retorna função de cleanup para remover o listener.
+ */
+export function initSessionSync(
+  onLogout: () => void
+): () => void {
+  if (typeof window === "undefined") return () => {};
+
+  let channel: BroadcastChannel;
+  try {
+    channel = new BroadcastChannel(SESSION_CHANNEL);
+  } catch {
+    // BroadcastChannel não disponível (ex: iframe sandbox)
+    return () => {};
+  }
+
+  const handler = (event: MessageEvent<SessionMessage>) => {
+    if (event.data.type === "LOGOUT" || event.data.type === "SESSION_EXPIRED") {
+      onLogout();
+    }
+  };
+
+  channel.addEventListener("message", handler);
+
+  return () => {
+    channel.removeEventListener("message", handler);
+    channel.close();
+  };
+}
+
+/**
+ * Envia broadcast de logout para todas as abas.
+ */
+export function broadcastLogout(): void {
+  if (typeof window === "undefined") return;
+  try {
+    const channel = new BroadcastChannel(SESSION_CHANNEL);
+    channel.postMessage({ type: "LOGOUT" } satisfies SessionMessage);
+    channel.close();
+  } catch {
+    // ignorar se não suportado
+  }
+}


### PR DESCRIPTION
## O que essa PR faz

Implementa a US-037: fundação de auth hardening que habilita a **Onda 2** das USs paralelas.

## Mudanças

### `lib/api-client.ts` ⭐ **Bloqueador da Onda 2**
Fetch wrapper client-side com:
- **Interceptor de 401**: pausa a fila de requests, tenta refresh, re-executa tudo
- **Mutex de refresh**: garante que apenas 1 refresh ocorre por vez (sem race condition)
- **Fila de requests paralelos**: requests que chegam durante o refresh são enfileirados e re-executados após
- **Fallback**: se refresh falhar → broadcast logout + redirect `/login?reason=session_expired`
- **`ApiError`**: classe de erro tipada com `.isUnauthorized`, `.isNotFound`, `.isServerError`

### `lib/session-sync.ts`
BroadcastChannel para sincronizar eventos de sessão entre abas:
- `initSessionSync(onLogout)` — registra listener, retorna cleanup
- `broadcastLogout()` — envia evento para outras abas

### `components/session-sync.tsx`
Client component que monta o listener no layout do dashboard.
Quando outra aba faz logout → redireciona para `/login?reason=session_expired`.

### `app/api/auth/logout`
- Notifica backend para invalidar o refresh token (best-effort)
- Expira ambos os cookies com `maxAge: 0` (correto) em vez de apenas `delete`

### `app/(dashboard)/layout.tsx`
- Adiciona `<SessionSync />`

### `app/(auth)/login/page.tsx`
- Exibe toast `"Sua sessão expirou"` quando `?reason=session_expired`

## Como usar em outras USs (Neo, Trinity)

```ts
import { apiFetch, ApiError } from '@/lib/api-client';

// GET
const items = await apiFetch<InventoryItem[]>('/api/proxy/inventory/products');

// POST
const item = await apiFetch<InventoryItem>('/api/proxy/inventory/products', {
  method: 'POST',
  body: JSON.stringify(payload),
});

// Tratamento de erro
try {
  await apiFetch('/api/proxy/...');
} catch (err) {
  if (err instanceof ApiError && err.isNotFound) { ... }
}
```

Closes #52