### PR TITLE
feat(US-038): Inventory CRUD no Frontend — Formulários e Dialogs Next.js

### DIFF
--- a/frontend/apps/next-shell/app/(dashboard)/inventory/[id]/page.tsx
+++ b/frontend/apps/next-shell/app/(dashboard)/inventory/[id]/page.tsx
@@ -1,0 +1,234 @@
+/**
+ * Inventory Product Detail — US-038
+ *
+ * Exibe detalhes do produto e histórico de movimentações de estoque.
+ */
+
+import { apiFetch } from "@/lib/api-fetch";
+import type { ProductDto, PagedResult, StockMovementDto } from "@/lib/types";
+import { StockStatusBadge } from "@/components/inventory/stock-status-badge";
+import Link from "next/link";
+import { ArrowLeft, Package } from "lucide-react";
+
+export const metadata = { title: "Produto — Inventário" };
+
+interface Props {
+  params: Promise<{ id: string }>;
+}
+
+async function fetchProduct(id: string) {
+  return apiFetch<ProductDto>(`/api/inventory/products/${id}`).catch(() => null);
+}
+
+async function fetchMovements(productId: string) {
+  return apiFetch<PagedResult<StockMovementDto>>(
+    `/api/inventory/stock-movements?productId=${productId}&pageSize=20`
+  ).catch(() => null);
+}
+
+export default async function InventoryProductPage({ params }: Props) {
+  const { id } = await params;
+  const [product, movements] = await Promise.all([
+    fetchProduct(id),
+    fetchMovements(id),
+  ]);
+
+  if (!product) {
+    return (
+      <div className="py-12 text-center text-gray-500">
+        Produto não encontrado.
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {/* Breadcrumb */}
+      <div className="mb-6">
+        <Link
+          href="/dashboard/inventory"
+          className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 mb-4"
+        >
+          <ArrowLeft size={15} />
+          Voltar ao inventário
+        </Link>
+
+        <div className="flex items-start gap-4">
+          <div className="w-12 h-12 rounded-xl bg-blue-100 flex items-center justify-center shrink-0">
+            <Package size={22} className="text-blue-600" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">{product.name}</h1>
+            <div className="flex items-center gap-3 mt-1">
+              <span className="text-sm text-gray-400 font-mono">{product.sku}</span>
+              <StockStatusBadge status={product.stockStatus} />
+              {!product.isActive && (
+                <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-500 border border-gray-200">
+                  Descontinuado
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Info Cards */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-6">
+        <Card label="Estoque atual" value={String(product.currentStock)} unit={product.unit} />
+        <Card label="Estoque mínimo" value={String(product.minimumStockLevel)} unit={product.unit} />
+        <Card label="Estoque máximo" value={String(product.maximumStockLevel)} unit={product.unit} />
+        <Card
+          label="Preço de venda"
+          value={product.unitPrice.toLocaleString("pt-BR", {
+            style: "currency",
+            currency: product.currency,
+          })}
+        />
+      </div>
+
+      {/* Details */}
+      <div className="bg-white rounded-xl border border-gray-200 p-5 mb-6 shadow-sm">
+        <h2 className="text-sm font-semibold text-gray-700 mb-3">Detalhes</h2>
+        <dl className="grid grid-cols-2 sm:grid-cols-3 gap-x-6 gap-y-3 text-sm">
+          <Detail label="Categoria" value={product.category} />
+          <Detail label="Unidade" value={product.unit} />
+          <Detail label="Moeda" value={product.currency} />
+          <Detail
+            label="Preço de custo"
+            value={product.costPrice.toLocaleString("pt-BR", {
+              style: "currency",
+              currency: product.currency,
+            })}
+          />
+          {product.barcode && <Detail label="Código de barras" value={product.barcode} />}
+          {product.expiryDate && (
+            <Detail
+              label="Validade"
+              value={new Date(product.expiryDate).toLocaleDateString("pt-BR")}
+            />
+          )}
+          {product.description && (
+            <div className="col-span-2 sm:col-span-3">
+              <dt className="text-gray-500">Descrição</dt>
+              <dd className="text-gray-800 mt-0.5">{product.description}</dd>
+            </div>
+          )}
+        </dl>
+      </div>
+
+      {/* Stock Movements */}
+      <div className="bg-white rounded-xl border border-gray-200 overflow-hidden shadow-sm">
+        <div className="px-5 py-4 border-b border-gray-200">
+          <h2 className="text-sm font-semibold text-gray-700">
+            Histórico de movimentações
+          </h2>
+        </div>
+
+        {!movements || movements.items.length === 0 ? (
+          <div className="p-8 text-center text-gray-500 text-sm">
+            Nenhuma movimentação registrada.
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 border-b border-gray-200">
+              <tr>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  Tipo
+                </th>
+                <th className="px-4 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  Qtd
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  Referência
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  Observações
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  Data
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {movements.items.map((m) => (
+                <tr key={m.id} className="hover:bg-gray-50">
+                  <td className="px-4 py-3">
+                    <MovementTypeBadge type={m.movementType} />
+                  </td>
+                  <td className="px-4 py-3 text-right font-mono text-gray-700">
+                    {m.quantity}
+                  </td>
+                  <td className="px-4 py-3 text-gray-600">{m.reference ?? "—"}</td>
+                  <td className="px-4 py-3 text-gray-500 max-w-xs truncate">
+                    {m.notes ?? "—"}
+                  </td>
+                  <td className="px-4 py-3 text-gray-500">
+                    {new Date(m.movementDate).toLocaleString("pt-BR")}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Card({
+  label,
+  value,
+  unit,
+}: {
+  label: string;
+  value: string;
+  unit?: string;
+}) {
+  return (
+    <div className="bg-white rounded-xl border border-gray-200 p-4 shadow-sm">
+      <p className="text-xs text-gray-500">{label}</p>
+      <p className="text-xl font-bold text-gray-900 mt-1">
+        {value}
+        {unit && <span className="text-sm font-normal text-gray-400 ml-1">{unit}</span>}
+      </p>
+    </div>
+  );
+}
+
+function Detail({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <dt className="text-gray-500">{label}</dt>
+      <dd className="text-gray-800 font-medium mt-0.5">{value}</dd>
+    </div>
+  );
+}
+
+const MOVEMENT_COLORS: Record<string, string> = {
+  In: "bg-green-100 text-green-700",
+  Out: "bg-red-100 text-red-700",
+  Adjustment: "bg-blue-100 text-blue-700",
+  Transfer: "bg-purple-100 text-purple-700",
+  Return: "bg-yellow-100 text-yellow-700",
+  Damage: "bg-orange-100 text-orange-700",
+  Loss: "bg-gray-100 text-gray-600",
+};
+
+const MOVEMENT_LABELS: Record<string, string> = {
+  In: "Entrada",
+  Out: "Saída",
+  Adjustment: "Ajuste",
+  Transfer: "Transferência",
+  Return: "Devolução",
+  Damage: "Avaria",
+  Loss: "Perda",
+};
+
+function MovementTypeBadge({ type }: { type: string }) {
+  const cls = MOVEMENT_COLORS[type] ?? "bg-gray-100 text-gray-600";
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${cls}`}>
+      {MOVEMENT_LABELS[type] ?? type}
+    </span>
+  );
+}

--- a/frontend/apps/next-shell/app/(dashboard)/inventory/page.tsx
+++ b/frontend/apps/next-shell/app/(dashboard)/inventory/page.tsx
@@ -1,18 +1,44 @@
-import { BlazorElement } from "@/components/blazor-element";
+/**
+ * Inventory Page — US-038
+ *
+ * Server Component: busca dados iniciais via api-fetch (server-side com token),
+ * repassa ao InventoryClient para CRUD interativo.
+ */
+
+import { apiFetch } from "@/lib/api-fetch";
+import type { PagedResult, ProductListDto } from "@/lib/types";
+import { InventoryClient } from "@/components/inventory/inventory-client";
 
 export const metadata = { title: "Inventário" };
 
-export default function InventoryPage() {
+interface SearchParams {
+  page?: string;
+  category?: string;
+  stockStatus?: string;
+  search?: string;
+}
+
+async function fetchProducts(params: SearchParams) {
+  const qs = new URLSearchParams({ page: params.page ?? "1", pageSize: "15" });
+  if (params.category) qs.set("category", params.category);
+  if (params.stockStatus) qs.set("stockStatus", params.stockStatus);
+  if (params.search) qs.set("search", params.search);
+  return apiFetch<PagedResult<ProductListDto>>(
+    `/api/inventory/products?${qs}`
+  ).catch(() => null);
+}
+
+export default async function InventoryPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const params = await searchParams;
+  const data = await fetchProducts(params);
+
   return (
     <div>
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold text-gray-900">Inventário</h1>
-        <p className="text-gray-500 text-sm mt-0.5">
-          Grid interativo com MudBlazor
-        </p>
-      </div>
-      {/* Custom Element Blazor — <inventory-grid> registrado via RegisterCustomElement */}
-      <BlazorElement tag="inventory-grid" apiBaseUrl="/api/proxy" />
+      <InventoryClient initialData={data} searchParams={params} />
     </div>
   );
 }

--- a/frontend/apps/next-shell/components/inventory/adjust-stock-dialog.tsx
+++ b/frontend/apps/next-shell/components/inventory/adjust-stock-dialog.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+/**
+ * AdjustStockDialog — US-038
+ *
+ * Dialog para ajuste de estoque de um produto.
+ */
+
+import { useEffect, useRef } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { X } from "lucide-react";
+
+const MOVEMENT_TYPES = [
+  { value: "In", label: "Entrada" },
+  { value: "Out", label: "Saída" },
+  { value: "Adjustment", label: "Ajuste" },
+  { value: "Return", label: "Devolução" },
+  { value: "Damage", label: "Avaria" },
+  { value: "Loss", label: "Perda" },
+] as const;
+
+const schema = z.object({
+  quantity: z.preprocess(Number, z.number().int().min(1, "Quantidade ≥ 1")),
+  movementType: z.enum(["In", "Out", "Adjustment", "Return", "Damage", "Loss"]),
+  reference: z.string().optional(),
+  notes: z.string().optional(),
+});
+
+type FormValues = {
+  quantity: number;
+  movementType: "In" | "Out" | "Adjustment" | "Return" | "Damage" | "Loss";
+  reference?: string;
+  notes?: string;
+};
+
+interface Props {
+  open: boolean;
+  productName?: string;
+  currentStock?: number;
+  onClose: () => void;
+  onSubmit: (data: FormValues) => Promise<void>;
+}
+
+export function AdjustStockDialog({
+  open,
+  productName,
+  currentStock,
+  onClose,
+  onSubmit,
+}: Props) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema) as import("react-hook-form").Resolver<FormValues>,
+    defaultValues: { movementType: "In", quantity: 1 },
+  });
+
+  useEffect(() => {
+    if (open) {
+      reset({ movementType: "In", quantity: 1 });
+      dialogRef.current?.showModal();
+    } else {
+      dialogRef.current?.close();
+    }
+  }, [open, reset]);
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onClose={onClose}
+      className="w-full max-w-md rounded-xl shadow-xl p-0 backdrop:bg-black/40 open:flex open:flex-col"
+    >
+      <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900">Ajustar Estoque</h2>
+          {productName && (
+            <p className="text-sm text-gray-500 mt-0.5">
+              {productName}
+              {currentStock !== undefined && (
+                <span className="ml-2 font-medium text-gray-700">
+                  (atual: {currentStock})
+                </span>
+              )}
+            </p>
+          )}
+        </div>
+        <button
+          onClick={onClose}
+          className="p-1 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+          aria-label="Fechar"
+        >
+          <X size={20} />
+        </button>
+      </div>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="px-6 py-5 space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Tipo de movimentação <span className="text-red-500">*</span>
+          </label>
+          <select
+            {...register("movementType")}
+            className="w-full px-3 py-2 rounded-lg border border-gray-300 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            {MOVEMENT_TYPES.map((m) => (
+              <option key={m.value} value={m.value}>
+                {m.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Quantidade <span className="text-red-500">*</span>
+          </label>
+          <input
+            type="number"
+            min={1}
+            {...register("quantity")}
+            className="w-full px-3 py-2 rounded-lg border border-gray-300 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          {errors.quantity && (
+            <p className="mt-1 text-xs text-red-500">{errors.quantity.message}</p>
+          )}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Referência / NF
+          </label>
+          <input
+            {...register("reference")}
+            placeholder="NF-001, PO-002..."
+            className="w-full px-3 py-2 rounded-lg border border-gray-300 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Observações
+          </label>
+          <textarea
+            {...register("notes")}
+            rows={2}
+            className="w-full px-3 py-2 rounded-lg border border-gray-300 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+          />
+        </div>
+
+        <div className="flex items-center justify-end gap-3 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+          >
+            Cancelar
+          </button>
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isSubmitting ? "Salvando..." : "Confirmar ajuste"}
+          </button>
+        </div>
+      </form>
+    </dialog>
+  );
+}

--- a/frontend/apps/next-shell/components/inventory/delete-confirm-dialog.tsx
+++ b/frontend/apps/next-shell/components/inventory/delete-confirm-dialog.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+/**
+ * DeleteConfirmDialog — US-038
+ *
+ * Dialog de confirmação para deletar um produto.
+ */
+
+import { useEffect, useRef } from "react";
+import { AlertTriangle, X } from "lucide-react";
+
+interface Props {
+  open: boolean;
+  productName?: string;
+  isDeleting?: boolean;
+  onClose: () => void;
+  onConfirm: () => Promise<void>;
+}
+
+export function DeleteConfirmDialog({
+  open,
+  productName,
+  isDeleting,
+  onClose,
+  onConfirm,
+}: Props) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    if (open) dialogRef.current?.showModal();
+    else dialogRef.current?.close();
+  }, [open]);
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onClose={onClose}
+      className="w-full max-w-sm rounded-xl shadow-xl p-0 backdrop:bg-black/40 open:flex open:flex-col"
+    >
+      <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+        <h2 className="text-lg font-semibold text-gray-900">Excluir produto</h2>
+        <button
+          onClick={onClose}
+          className="p-1 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+          aria-label="Fechar"
+        >
+          <X size={20} />
+        </button>
+      </div>
+
+      <div className="px-6 py-5">
+        <div className="flex items-start gap-4">
+          <div className="shrink-0 w-10 h-10 rounded-full bg-red-100 flex items-center justify-center">
+            <AlertTriangle size={20} className="text-red-600" />
+          </div>
+          <div>
+            <p className="text-sm text-gray-700">
+              Tem certeza que deseja excluir{" "}
+              <span className="font-semibold">{productName ?? "este produto"}</span>?
+            </p>
+            <p className="mt-1 text-xs text-gray-500">
+              Esta ação não pode ser desfeita.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-gray-200 bg-gray-50">
+        <button
+          onClick={onClose}
+          className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+        >
+          Cancelar
+        </button>
+        <button
+          onClick={onConfirm}
+          disabled={isDeleting}
+          className="px-4 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {isDeleting ? "Excluindo..." : "Excluir"}
+        </button>
+      </div>
+    </dialog>
+  );
+}

--- a/frontend/apps/next-shell/components/inventory/inventory-client.tsx
+++ b/frontend/apps/next-shell/components/inventory/inventory-client.tsx
@@ -1,0 +1,385 @@
+"use client";
+
+/**
+ * InventoryClient — US-038
+ *
+ * Componente client-side que gerencia todo o CRUD de produtos de inventário.
+ * Usa apiFetch (api-client.ts) com refresh token automático.
+ */
+
+import { useState, useCallback, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Plus, Pencil, Trash2, RefreshCw, BarChart3 } from "lucide-react";
+import { toast } from "sonner";
+import { StockStatusBadge } from "@/components/inventory/stock-status-badge";
+import { ProductFormDialog } from "@/components/inventory/product-form-dialog";
+import { AdjustStockDialog } from "@/components/inventory/adjust-stock-dialog";
+import { DeleteConfirmDialog } from "@/components/inventory/delete-confirm-dialog";
+import {
+  getProducts,
+  createProduct,
+  updateProduct,
+  adjustStock,
+  deleteProduct,
+  getProductById,
+} from "@/lib/api/inventory";
+import type {
+  ProductListDto,
+  ProductDto,
+  PagedResult,
+  CreateProductRequest,
+  UpdateProductRequest,
+  AdjustStockRequest,
+} from "@/lib/types";
+
+interface Props {
+  initialData: PagedResult<ProductListDto> | null;
+  searchParams: {
+    page?: string;
+    category?: string;
+    stockStatus?: string;
+    search?: string;
+  };
+}
+
+export function InventoryClient({ initialData, searchParams }: Props) {
+  const router = useRouter();
+  const [data, setData] = useState(initialData);
+  const [isPending, startTransition] = useTransition();
+
+  // Dialog state
+  const [formOpen, setFormOpen] = useState(false);
+  const [adjustOpen, setAdjustOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const [selectedProduct, setSelectedProduct] = useState<ProductDto | null>(null);
+  const [selectedListItem, setSelectedListItem] = useState<ProductListDto | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  // ── Refresh ────────────────────────────────────────────────────────────
+  const refreshData = useCallback(async () => {
+    try {
+      const fresh = await getProducts({
+        page: Number(searchParams.page ?? 1),
+        pageSize: 15,
+        category: searchParams.category,
+        stockStatus: searchParams.stockStatus,
+        search: searchParams.search,
+      });
+      setData(fresh);
+    } catch {
+      toast.error("Erro ao atualizar lista de produtos");
+    }
+  }, [searchParams]);
+
+  // ── Create ─────────────────────────────────────────────────────────────
+  const handleCreate = async (values: CreateProductRequest) => {
+    await createProduct(values);
+    toast.success("Produto criado com sucesso!");
+    setFormOpen(false);
+    await refreshData();
+  };
+
+  // ── Edit ───────────────────────────────────────────────────────────────
+  const openEdit = async (item: ProductListDto) => {
+    try {
+      const full = await getProductById(item.id);
+      setSelectedProduct(full);
+      setFormOpen(true);
+    } catch {
+      toast.error("Erro ao carregar produto");
+    }
+  };
+
+  const handleUpdate = async (values: UpdateProductRequest) => {
+    if (!selectedProduct) return;
+    await updateProduct(selectedProduct.id, values);
+    toast.success("Produto atualizado com sucesso!");
+    setFormOpen(false);
+    setSelectedProduct(null);
+    await refreshData();
+  };
+
+  // ── Adjust Stock ───────────────────────────────────────────────────────
+  const openAdjust = (item: ProductListDto) => {
+    setSelectedListItem(item);
+    setAdjustOpen(true);
+  };
+
+  const handleAdjust = async (values: AdjustStockRequest) => {
+    if (!selectedListItem) return;
+    await adjustStock(selectedListItem.id, values);
+    toast.success("Estoque ajustado com sucesso!");
+    setAdjustOpen(false);
+    setSelectedListItem(null);
+    await refreshData();
+  };
+
+  // ── Delete ─────────────────────────────────────────────────────────────
+  const openDelete = (item: ProductListDto) => {
+    setSelectedListItem(item);
+    setDeleteOpen(true);
+  };
+
+  const handleDelete = async () => {
+    if (!selectedListItem) return;
+    setIsDeleting(true);
+    try {
+      await deleteProduct(selectedListItem.id);
+      toast.success("Produto excluído com sucesso!");
+      setDeleteOpen(false);
+      setSelectedListItem(null);
+      await refreshData();
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  // ── Navigation ─────────────────────────────────────────────────────────
+  const navigate = (params: Record<string, string | undefined>) => {
+    const qs = new URLSearchParams();
+    const merged = { ...searchParams, ...params };
+    Object.entries(merged).forEach(([k, v]) => {
+      if (v) qs.set(k, v);
+    });
+    startTransition(() => router.push(`/dashboard/inventory?${qs}`));
+  };
+
+  const CATEGORIES = [
+    "Electronics",
+    "Machinery",
+    "RawMaterial",
+    "Consumable",
+    "Furniture",
+    "Tool",
+    "Spare",
+    "Other",
+  ];
+  const STOCK_STATUSES = ["Normal", "Low", "Critical", "Overstock", "OutOfStock"];
+
+  return (
+    <>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-900">Inventário</h1>
+          <p className="text-gray-500 text-sm mt-0.5">
+            {data ? `${data.totalCount} produtos` : "Carregando..."}
+          </p>
+        </div>
+        <button
+          onClick={() => {
+            setSelectedProduct(null);
+            setFormOpen(true);
+          }}
+          className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-500 transition-colors"
+        >
+          <Plus size={16} />
+          Novo Produto
+        </button>
+      </div>
+
+      {/* Filtros */}
+      <form
+        className="flex flex-wrap gap-3 mb-4"
+        onSubmit={(e) => {
+          e.preventDefault();
+          const fd = new FormData(e.currentTarget);
+          navigate({
+            search: (fd.get("search") as string) || undefined,
+            category: (fd.get("category") as string) || undefined,
+            stockStatus: (fd.get("stockStatus") as string) || undefined,
+            page: "1",
+          });
+        }}
+      >
+        <input
+          name="search"
+          defaultValue={searchParams.search}
+          placeholder="Buscar por nome, SKU..."
+          className="flex-1 min-w-48 px-3 py-2 rounded-lg border border-gray-300 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+        <select
+          name="category"
+          defaultValue={searchParams.category ?? ""}
+          className="px-3 py-2 rounded-lg border border-gray-300 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          <option value="">Todas as categorias</option>
+          {CATEGORIES.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+        <select
+          name="stockStatus"
+          defaultValue={searchParams.stockStatus ?? ""}
+          className="px-3 py-2 rounded-lg border border-gray-300 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          <option value="">Todos os status</option>
+          {STOCK_STATUSES.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+        <button
+          type="submit"
+          className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-500 transition-colors"
+        >
+          Filtrar
+        </button>
+      </form>
+
+      {/* Tabela */}
+      {!data ? (
+        <div className="bg-white rounded-xl border border-gray-200 p-8 text-center text-gray-500">
+          Erro ao carregar produtos. Verifique se o servidor está rodando.
+        </div>
+      ) : data.items.length === 0 ? (
+        <div className="bg-white rounded-xl border border-gray-200 p-12 text-center">
+          <p className="text-gray-500">Nenhum produto encontrado.</p>
+        </div>
+      ) : (
+        <div className="bg-white rounded-xl border border-gray-200 overflow-hidden shadow-sm">
+          <table className="w-full text-sm">
+            <thead className="bg-gray-50 border-b border-gray-200">
+              <tr>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  Nome / SKU
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  Categoria
+                </th>
+                <th className="px-4 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  Estoque
+                </th>
+                <th className="px-4 py-3 text-right text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  Preço
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                  Status
+                </th>
+                <th className="px-4 py-3" />
+              </tr>
+            </thead>
+            <tbody className={`divide-y divide-gray-100 ${isPending ? "opacity-50" : ""}`}>
+              {data.items.map((item) => (
+                <tr key={item.id} className="hover:bg-gray-50 transition-colors">
+                  <td className="px-4 py-3">
+                    <div className="font-medium text-gray-900 truncate max-w-xs">
+                      {item.name}
+                    </div>
+                    <div className="text-xs text-gray-400 font-mono">{item.sku}</div>
+                  </td>
+                  <td className="px-4 py-3 text-gray-600">{item.category}</td>
+                  <td className="px-4 py-3 text-right font-mono text-gray-700">
+                    {item.currentStock}
+                  </td>
+                  <td className="px-4 py-3 text-right text-gray-700">
+                    {item.unitPrice.toLocaleString("pt-BR", {
+                      style: "currency",
+                      currency: "BRL",
+                    })}
+                  </td>
+                  <td className="px-4 py-3">
+                    <StockStatusBadge status={item.stockStatus} />
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center justify-end gap-1">
+                      <button
+                        onClick={() => openAdjust(item)}
+                        title="Ajustar estoque"
+                        className="p-1.5 rounded-lg text-gray-400 hover:text-blue-600 hover:bg-blue-50 transition-colors"
+                      >
+                        <RefreshCw size={15} />
+                      </button>
+                      <button
+                        onClick={() => router.push(`/dashboard/inventory/${item.id}`)}
+                        title="Ver movimentações"
+                        className="p-1.5 rounded-lg text-gray-400 hover:text-purple-600 hover:bg-purple-50 transition-colors"
+                      >
+                        <BarChart3 size={15} />
+                      </button>
+                      <button
+                        onClick={() => openEdit(item)}
+                        title="Editar"
+                        className="p-1.5 rounded-lg text-gray-400 hover:text-green-600 hover:bg-green-50 transition-colors"
+                      >
+                        <Pencil size={15} />
+                      </button>
+                      <button
+                        onClick={() => openDelete(item)}
+                        title="Excluir"
+                        className="p-1.5 rounded-lg text-gray-400 hover:text-red-600 hover:bg-red-50 transition-colors"
+                      >
+                        <Trash2 size={15} />
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {/* Paginação */}
+          <div className="px-4 py-3 border-t border-gray-200 flex items-center justify-between text-sm text-gray-500">
+            <span>
+              Página {data.pageNumber} de {data.totalPages}
+            </span>
+            <div className="flex gap-2">
+              {data.pageNumber > 1 && (
+                <button
+                  onClick={() => navigate({ page: String(data.pageNumber - 1) })}
+                  className="px-3 py-1 rounded border border-gray-300 hover:bg-gray-50"
+                >
+                  Anterior
+                </button>
+              )}
+              {data.pageNumber < data.totalPages && (
+                <button
+                  onClick={() => navigate({ page: String(data.pageNumber + 1) })}
+                  className="px-3 py-1 rounded border border-gray-300 hover:bg-gray-50"
+                >
+                  Próxima
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Dialogs */}
+      <ProductFormDialog
+        open={formOpen}
+        product={selectedProduct}
+        onClose={() => {
+          setFormOpen(false);
+          setSelectedProduct(null);
+        }}
+        onSubmit={selectedProduct ? handleUpdate : handleCreate}
+      />
+
+      <AdjustStockDialog
+        open={adjustOpen}
+        productName={selectedListItem?.name}
+        currentStock={selectedListItem?.currentStock}
+        onClose={() => {
+          setAdjustOpen(false);
+          setSelectedListItem(null);
+        }}
+        onSubmit={handleAdjust}
+      />
+
+      <DeleteConfirmDialog
+        open={deleteOpen}
+        productName={selectedListItem?.name}
+        isDeleting={isDeleting}
+        onClose={() => {
+          setDeleteOpen(false);
+          setSelectedListItem(null);
+        }}
+        onConfirm={handleDelete}
+      />
+    </>
+  );
+}

--- a/frontend/apps/next-shell/components/inventory/product-form-dialog.tsx
+++ b/frontend/apps/next-shell/components/inventory/product-form-dialog.tsx
@@ -1,0 +1,331 @@
+"use client";
+
+/**
+ * ProductFormDialog — US-038
+ *
+ * Dialog para criar ou editar um produto de inventário.
+ * Usa react-hook-form + zod para validação.
+ */
+
+import { useEffect, useRef } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { X } from "lucide-react";
+import type { ProductDto } from "@/lib/types";
+
+const CATEGORIES = [
+  "Electronics",
+  "Machinery",
+  "RawMaterial",
+  "Consumable",
+  "Furniture",
+  "Tool",
+  "Spare",
+  "Other",
+] as const;
+
+const schema = z.object({
+  name: z.string().min(2, "Nome obrigatório"),
+  sku: z.string().min(1, "SKU obrigatório"),
+  category: z.enum(CATEGORIES),
+  description: z.string().optional(),
+  barcode: z.string().optional(),
+  minimumStockLevel: z.preprocess(Number, z.number().int().min(0, "Mínimo ≥ 0")),
+  maximumStockLevel: z.preprocess(Number, z.number().int().min(1, "Máximo ≥ 1")),
+  unitPrice: z.preprocess(Number, z.number().min(0, "Preço ≥ 0")),
+  costPrice: z.preprocess(Number, z.number().min(0, "Custo ≥ 0")),
+  unit: z.string().min(1, "Unidade obrigatória"),
+  currency: z.string().min(1, "Moeda obrigatória"),
+});
+
+type FormValues = {
+  name: string;
+  sku: string;
+  category: (typeof CATEGORIES)[number];
+  description?: string;
+  barcode?: string;
+  minimumStockLevel: number;
+  maximumStockLevel: number;
+  unitPrice: number;
+  costPrice: number;
+  unit: string;
+  currency: string;
+};
+
+interface Props {
+  open: boolean;
+  product?: ProductDto | null;
+  onClose: () => void;
+  onSubmit: (data: FormValues) => Promise<void>;
+}
+
+export function ProductFormDialog({ open, product, onClose, onSubmit }: Props) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema) as import("react-hook-form").Resolver<FormValues>,
+    defaultValues: {
+      unit: "un",
+      currency: "BRL",
+      minimumStockLevel: 0,
+      maximumStockLevel: 100,
+      unitPrice: 0,
+      costPrice: 0,
+    },
+  });
+
+  // Sincroniza com produto existente ao editar
+  useEffect(() => {
+    if (product) {
+      reset({
+        name: product.name,
+        sku: product.sku,
+        category: product.category as (typeof CATEGORIES)[number],
+        description: product.description ?? "",
+        barcode: product.barcode ?? "",
+        minimumStockLevel: product.minimumStockLevel,
+        maximumStockLevel: product.maximumStockLevel,
+        unitPrice: product.unitPrice,
+        costPrice: product.costPrice,
+        unit: product.unit,
+        currency: product.currency,
+      });
+    } else {
+      reset({
+        unit: "un",
+        currency: "BRL",
+        minimumStockLevel: 0,
+        maximumStockLevel: 100,
+        unitPrice: 0,
+        costPrice: 0,
+      });
+    }
+  }, [product, reset]);
+
+  useEffect(() => {
+    if (open) dialogRef.current?.showModal();
+    else dialogRef.current?.close();
+  }, [open]);
+
+  const handleClose = () => {
+    onClose();
+  };
+
+  const handleFormSubmit = async (values: FormValues) => {
+    await onSubmit(values);
+  };
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onClose={handleClose}
+      className="w-full max-w-2xl rounded-xl shadow-xl p-0 backdrop:bg-black/40 open:flex open:flex-col"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+        <h2 className="text-lg font-semibold text-gray-900">
+          {product ? "Editar Produto" : "Novo Produto"}
+        </h2>
+        <button
+          onClick={handleClose}
+          className="p-1 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors"
+          aria-label="Fechar"
+        >
+          <X size={20} />
+        </button>
+      </div>
+
+      {/* Form */}
+      <form
+        onSubmit={handleSubmit(handleFormSubmit)}
+        className="overflow-y-auto max-h-[80vh]"
+      >
+        <div className="px-6 py-5 grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {/* Nome */}
+          <div className="sm:col-span-2">
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Nome <span className="text-red-500">*</span>
+            </label>
+            <input
+              {...register("name")}
+              className="w-full px-3 py-2 rounded-lg border border-gray-300 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="Nome do produto"
+            />
+            {errors.name && (
+              <p className="mt-1 text-xs text-red-500">{errors.name.message}</p>
+            )}
+          </div>
+
+          {/* SKU */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              SKU <span className="text-red-500">*</span>
+            </label>
+            <input
+              {...register("sku")}
+              disabled={!!product}
+              className="w-full px-3 py-2 rounded-lg border border-gray-300 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-50 disabled:text-gray-500"
+              placeholder="EX-0001"
+            />
+            {errors.sku && (
+              <p className="mt-1 text-xs text-red-500">{errors.sku.message}</p>
+            )}
+          </div>
+
+          {/* Categoria */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Categoria <span className="text-red-500">*</span>
+            </label>
+            <select
+              {...register("category")}
+              className="w-full px-3 py-2 rounded-lg border border-gray-300 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              {CATEGORIES.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+            {errors.category && (
+              <p className="mt-1 text-xs text-red-500">
+                {errors.category.message}
+              </p>
+            )}
+          </div>
+
+          {/* Barcode */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Código de barras
+            </label>
+            <input
+              {...register("barcode")}
+              className="w-full px-3 py-2 rounded-lg border border-gray-300 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="123456789"
+            />
+          </div>
+
+          {/* Unidade */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Unidade <span className="text-red-500">*</span>
+            </label>
+            <input
+              {...register("unit")}
+              className="w-full px-3 py-2 rounded-lg border border-gray-300 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="un, kg, l..."
+            />
+          </div>
+
+          {/* Estoque mínimo */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Estoque mínimo <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="number"
+              {...register("minimumStockLevel")}
+              className="w-full px-3 py-2 rounded-lg border border-gray-300 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            {errors.minimumStockLevel && (
+              <p className="mt-1 text-xs text-red-500">
+                {errors.minimumStockLevel.message}
+              </p>
+            )}
+          </div>
+
+          {/* Estoque máximo */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Estoque máximo <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="number"
+              {...register("maximumStockLevel")}
+              className="w-full px-3 py-2 rounded-lg border border-gray-300 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            {errors.maximumStockLevel && (
+              <p className="mt-1 text-xs text-red-500">
+                {errors.maximumStockLevel.message}
+              </p>
+            )}
+          </div>
+
+          {/* Preço de venda */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Preço de venda (R$) <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="number"
+              step="0.01"
+              {...register("unitPrice")}
+              className="w-full px-3 py-2 rounded-lg border border-gray-300 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            {errors.unitPrice && (
+              <p className="mt-1 text-xs text-red-500">
+                {errors.unitPrice.message}
+              </p>
+            )}
+          </div>
+
+          {/* Preço de custo */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Preço de custo (R$) <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="number"
+              step="0.01"
+              {...register("costPrice")}
+              className="w-full px-3 py-2 rounded-lg border border-gray-300 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            {errors.costPrice && (
+              <p className="mt-1 text-xs text-red-500">
+                {errors.costPrice.message}
+              </p>
+            )}
+          </div>
+
+          {/* Descrição */}
+          <div className="sm:col-span-2">
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Descrição
+            </label>
+            <textarea
+              {...register("description")}
+              rows={3}
+              className="w-full px-3 py-2 rounded-lg border border-gray-300 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+              placeholder="Descrição opcional do produto..."
+            />
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-gray-200 bg-gray-50">
+          <button
+            type="button"
+            onClick={handleClose}
+            className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+          >
+            Cancelar
+          </button>
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isSubmitting ? "Salvando..." : product ? "Salvar alterações" : "Criar produto"}
+          </button>
+        </div>
+      </form>
+    </dialog>
+  );
+}

--- a/frontend/apps/next-shell/components/inventory/stock-status-badge.tsx
+++ b/frontend/apps/next-shell/components/inventory/stock-status-badge.tsx
@@ -1,0 +1,47 @@
+/**
+ * StockStatusBadge — US-038
+ * Exibe o status de estoque do produto com cores semânticas.
+ */
+
+import type { StockStatus } from "@/lib/types";
+
+const CONFIG: Record<StockStatus, { label: string; className: string }> = {
+  Normal: {
+    label: "Normal",
+    className: "bg-green-100 text-green-700 border-green-200",
+  },
+  Low: {
+    label: "Baixo",
+    className: "bg-yellow-100 text-yellow-700 border-yellow-200",
+  },
+  Critical: {
+    label: "Crítico",
+    className: "bg-red-100 text-red-700 border-red-200",
+  },
+  Overstock: {
+    label: "Excesso",
+    className: "bg-blue-100 text-blue-700 border-blue-200",
+  },
+  OutOfStock: {
+    label: "Sem estoque",
+    className: "bg-gray-100 text-gray-600 border-gray-200",
+  },
+};
+
+interface Props {
+  status: string;
+}
+
+export function StockStatusBadge({ status }: Props) {
+  const cfg = CONFIG[status as StockStatus] ?? {
+    label: status,
+    className: "bg-gray-100 text-gray-600 border-gray-200",
+  };
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border ${cfg.className}`}
+    >
+      {cfg.label}
+    </span>
+  );
+}

--- a/frontend/apps/next-shell/lib/api/inventory.ts
+++ b/frontend/apps/next-shell/lib/api/inventory.ts
@@ -1,0 +1,117 @@
+/**
+ * lib/api/inventory.ts — US-038
+ *
+ * Funções client-side para o módulo de Inventário.
+ * Usa apiFetch (api-client.ts) com interceptor de refresh token.
+ * Todas as chamadas passam pelo BFF proxy: /api/proxy/inventory/*
+ */
+
+import { apiFetch } from "@/lib/api-client";
+import type {
+  ProductDto,
+  ProductListDto,
+  CreateProductRequest,
+  UpdateProductRequest,
+  AdjustStockRequest,
+  StockMovementDto,
+  SupplierListDto,
+  LocationListDto,
+  PagedResult,
+} from "@/lib/types";
+
+const BASE = "/api/proxy/inventory";
+
+// ── Products ────────────────────────────────────────────────────────────────
+
+export interface GetProductsParams {
+  page?: number;
+  pageSize?: number;
+  category?: string;
+  stockStatus?: string;
+  search?: string;
+  locationId?: string;
+  supplierId?: string;
+}
+
+export function getProducts(params: GetProductsParams = {}) {
+  const qs = new URLSearchParams();
+  if (params.page) qs.set("page", String(params.page));
+  if (params.pageSize) qs.set("pageSize", String(params.pageSize));
+  if (params.category) qs.set("category", params.category);
+  if (params.stockStatus) qs.set("stockStatus", params.stockStatus);
+  if (params.search) qs.set("search", params.search);
+  if (params.locationId) qs.set("locationId", params.locationId);
+  if (params.supplierId) qs.set("supplierId", params.supplierId);
+  return apiFetch<PagedResult<ProductListDto>>(`${BASE}/products?${qs}`);
+}
+
+export function getProductById(id: string) {
+  return apiFetch<ProductDto>(`${BASE}/products/${id}`);
+}
+
+export function createProduct(data: CreateProductRequest) {
+  return apiFetch<ProductDto>(`${BASE}/products`, {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export function updateProduct(id: string, data: UpdateProductRequest) {
+  return apiFetch<ProductDto>(`${BASE}/products/${id}`, {
+    method: "PUT",
+    body: JSON.stringify(data),
+  });
+}
+
+export function adjustStock(id: string, data: AdjustStockRequest) {
+  return apiFetch<void>(`${BASE}/products/${id}/stock/adjust`, {
+    method: "PATCH",
+    body: JSON.stringify(data),
+  });
+}
+
+export function discontinueProduct(id: string) {
+  return apiFetch<void>(`${BASE}/products/${id}/discontinue`, {
+    method: "PATCH",
+  });
+}
+
+export function deleteProduct(id: string) {
+  return apiFetch<void>(`${BASE}/products/${id}`, {
+    method: "DELETE",
+  });
+}
+
+// ── Stock Movements ─────────────────────────────────────────────────────────
+
+export interface GetMovementsParams {
+  page?: number;
+  pageSize?: number;
+  productId?: string;
+  movementType?: string;
+}
+
+export function getStockMovements(params: GetMovementsParams = {}) {
+  const qs = new URLSearchParams();
+  if (params.page) qs.set("page", String(params.page));
+  if (params.pageSize) qs.set("pageSize", String(params.pageSize));
+  if (params.productId) qs.set("productId", params.productId);
+  if (params.movementType) qs.set("movementType", params.movementType);
+  return apiFetch<PagedResult<StockMovementDto>>(`${BASE}/stock-movements?${qs}`);
+}
+
+// ── Suppliers ───────────────────────────────────────────────────────────────
+
+export function getSuppliers(page = 1, pageSize = 100) {
+  return apiFetch<PagedResult<SupplierListDto>>(
+    `${BASE}/suppliers?page=${page}&pageSize=${pageSize}`
+  );
+}
+
+// ── Locations ───────────────────────────────────────────────────────────────
+
+export function getLocations(page = 1, pageSize = 100) {
+  return apiFetch<PagedResult<LocationListDto>>(
+    `${BASE}/locations?page=${page}&pageSize=${pageSize}`
+  );
+}

--- a/frontend/apps/next-shell/lib/types.ts
+++ b/frontend/apps/next-shell/lib/types.ts
@@ -55,6 +55,133 @@ export interface UpdateIssueRequest {
 
 // ─── Inventory ────────────────────────────────────────────────────────────────
 
+export type ProductCategory =
+  | "Electronics"
+  | "Machinery"
+  | "RawMaterial"
+  | "Consumable"
+  | "Furniture"
+  | "Tool"
+  | "Spare"
+  | "Other";
+
+export type StockStatus = "Normal" | "Low" | "Critical" | "Overstock" | "OutOfStock";
+
+export type StockMovementType =
+  | "In"
+  | "Out"
+  | "Transfer"
+  | "Adjustment"
+  | "Return"
+  | "Damage"
+  | "Loss";
+
+export interface ProductListDto {
+  id: string;
+  name: string;
+  sku: string;
+  category: string;
+  currentStock: number;
+  unitPrice: number;
+  stockStatus: StockStatus;
+  isActive: boolean;
+  createdAt: string;
+}
+
+export interface ProductDto {
+  id: string;
+  name: string;
+  sku: string;
+  barcode?: string;
+  description?: string;
+  category: string;
+  currentStock: number;
+  minimumStockLevel: number;
+  maximumStockLevel: number;
+  unitPrice: number;
+  costPrice: number;
+  unit: string;
+  currency: string;
+  locationId?: string;
+  supplierId?: string;
+  expiryDate?: string;
+  stockStatus: StockStatus;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt?: string;
+}
+
+export interface CreateProductRequest {
+  name: string;
+  sku: string;
+  category: ProductCategory;
+  minimumStockLevel: number;
+  maximumStockLevel: number;
+  unitPrice: number;
+  costPrice: number;
+  description?: string;
+  barcode?: string;
+  unit?: string;
+  currency?: string;
+  locationId?: string;
+  supplierId?: string;
+  expiryDate?: string;
+}
+
+export interface UpdateProductRequest {
+  name: string;
+  description?: string;
+  category: ProductCategory;
+  minimumStockLevel: number;
+  maximumStockLevel: number;
+  barcode?: string;
+  unit: string;
+  currency: string;
+  locationId?: string;
+  supplierId?: string;
+  expiryDate?: string;
+}
+
+export interface AdjustStockRequest {
+  quantity: number;
+  movementType: StockMovementType;
+  reference?: string;
+  notes?: string;
+}
+
+export interface StockMovementDto {
+  id: string;
+  productId: string;
+  productName?: string;
+  productSKU?: string;
+  movementType: string;
+  quantity: number;
+  locationId?: string;
+  locationName?: string;
+  reference?: string;
+  notes?: string;
+  movementDate: string;
+}
+
+export interface SupplierListDto {
+  id: string;
+  name: string;
+  code: string;
+  contactPerson?: string;
+  email?: string;
+  isActive: boolean;
+}
+
+export interface LocationListDto {
+  id: string;
+  name: string;
+  code: string;
+  type: string;
+  capacity: number;
+  isActive: boolean;
+}
+
+/** @deprecated use ProductDto instead */
 export interface InventoryItemDto {
   id: string;
   name: string;


### PR DESCRIPTION
## O que essa PR faz (Neo)

Implementa a US-038: CRUD completo de inventário no frontend Next.js usando BFF + `api-client`.

## Mudanças

- `lib/api/inventory.ts` — funções tipadas para listar, criar, editar, excluir produtos via `apiFetch`
- `components/inventory/inventory-client.tsx` — tabela client-side com paginação e busca
- `components/inventory/product-form-dialog.tsx` — dialog de criação/edição (React Hook Form + Zod)
- `components/inventory/delete-confirm-dialog.tsx` — confirmação de exclusão
- `components/inventory/adjust-stock-dialog.tsx` — ajuste de quantidade em estoque
- `components/inventory/stock-status-badge.tsx` — badge de status (crítico/baixo/normal)
- `app/(dashboard)/inventory/page.tsx` — página atualizada com InventoryClient
- `app/(dashboard)/inventory/[id]/page.tsx` — detalhe do produto
- `lib/types.ts` — DTOs de inventory atualizados
- `messages/pt.json` + `messages/en.json` — strings de inventory adicionadas

> ⚠️ Removido `middleware.ts` duplicado (conflito com `proxy.ts` — já consolidado na US-042)

Closes #53