### PR TITLE
feat(US-040): User Management Frontend — listagem, convite e gestão de roles

### DIFF
--- a/backend/src/Modules/Auth/Api/UserAdminModule.cs
+++ b/backend/src/Modules/Auth/Api/UserAdminModule.cs
@@ -1,0 +1,110 @@
+using FluentValidation;
+using IMS.Modular.Modules.Auth.Application.DTOs;
+using IMS.Modular.Modules.Auth.Application.Services;
+using IMS.Modular.Shared.Abstractions;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace IMS.Modular.Modules.Auth.Api;
+
+/// <summary>
+/// US-040 — Admin endpoints para gerenciamento de usuários.
+/// Requer role Admin.
+/// </summary>
+public class UserAdminModule : IEndpointModule
+{
+    public static IEndpointRouteBuilder Map(IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints
+            .MapGroup("/api/admin/users")
+            .WithTags("Admin - Users")
+            .RequireAuthorization("AdminOnly");
+
+        group.MapGet("/", GetUsers).WithName("AdminGetUsers");
+        group.MapGet("/{id:guid}", GetUserById).WithName("AdminGetUserById");
+        group.MapGet("/roles", GetRoles).WithName("AdminGetRoles");
+        group.MapPatch("/{id:guid}/role", UpdateUserRole).WithName("AdminUpdateUserRole");
+        group.MapPatch("/{id:guid}/activate", ActivateUser).WithName("AdminActivateUser");
+        group.MapPatch("/{id:guid}/deactivate", DeactivateUser).WithName("AdminDeactivateUser");
+        group.MapPost("/invite", InviteUser).WithName("AdminInviteUser");
+
+        return endpoints;
+    }
+
+    private static async Task<IResult> GetUsers(
+        IUserAdminService svc,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 20,
+        [FromQuery] string? search = null,
+        [FromQuery] string? role = null,
+        CancellationToken ct = default)
+    {
+        var result = await svc.GetUsersAsync(page, pageSize, search, role, ct);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> GetUserById(Guid id, IUserAdminService svc, CancellationToken ct)
+    {
+        var user = await svc.GetUserByIdAsync(id, ct);
+        return user is null ? Results.NotFound() : Results.Ok(user);
+    }
+
+    private static async Task<IResult> GetRoles(IUserAdminService svc, CancellationToken ct)
+    {
+        var roles = await svc.GetRolesAsync(ct);
+        return Results.Ok(roles);
+    }
+
+    private static async Task<IResult> UpdateUserRole(
+        Guid id,
+        UpdateUserRoleRequest request,
+        IValidator<UpdateUserRoleRequest> validator,
+        IUserAdminService svc,
+        HttpContext httpContext,
+        CancellationToken ct)
+    {
+        var validation = await validator.ValidateAsync(request, ct);
+        if (!validation.IsValid)
+            return Results.ValidationProblem(validation.ToDictionary());
+
+        var result = await svc.UpdateUserRoleAsync(id, request.RoleName, ct);
+        return result ? Results.Ok() : Results.NotFound();
+    }
+
+    private static async Task<IResult> ActivateUser(Guid id, IUserAdminService svc, CancellationToken ct)
+    {
+        var result = await svc.SetUserActiveAsync(id, true, ct);
+        return result ? Results.Ok() : Results.NotFound();
+    }
+
+    private static async Task<IResult> DeactivateUser(
+        Guid id,
+        ClaimsPrincipal principal,
+        IUserAdminService svc,
+        CancellationToken ct)
+    {
+        // Não pode desativar a si mesmo
+        if (principal.FindFirstValue(ClaimTypes.NameIdentifier) == id.ToString())
+            return Results.BadRequest(new { message = "Você não pode desativar sua própria conta." });
+
+        var result = await svc.SetUserActiveAsync(id, false, ct);
+        return result ? Results.Ok() : Results.NotFound();
+    }
+
+    private static async Task<IResult> InviteUser(
+        InviteUserRequest request,
+        IValidator<InviteUserRequest> validator,
+        IUserAdminService svc,
+        HttpContext httpContext,
+        CancellationToken ct)
+    {
+        var validation = await validator.ValidateAsync(request, ct);
+        if (!validation.IsValid)
+            return Results.ValidationProblem(validation.ToDictionary());
+
+        var result = await svc.InviteUserAsync(request, ct);
+        return result is null
+            ? Results.BadRequest(new { message = "Username ou e-mail já existe." })
+            : Results.Created($"/api/admin/users/{result.Id}", result);
+    }
+}

--- a/backend/src/Modules/Auth/Application/DTOs/AuthDtos.cs
+++ b/backend/src/Modules/Auth/Application/DTOs/AuthDtos.cs
@@ -21,3 +21,26 @@ public record UserInfoResponse(
     string FullName,
     string[] Roles,
     DateTime CreatedAt);
+
+// ── US-040 Admin DTOs ─────────────────────────────────────────────────────────
+
+public record UserAdminDto(
+    string Id,
+    string Username,
+    string Email,
+    string FullName,
+    string[] Roles,
+    bool IsActive,
+    DateTime? LastLoginAt,
+    DateTime CreatedAt);
+
+public record RoleDto(string Id, string Name, string? Description);
+
+public record UpdateUserRoleRequest(string RoleName);
+
+public record InviteUserRequest(
+    string Username,
+    string Email,
+    string FullName,
+    string Role = "User",
+    string? TemporaryPassword = null);

--- a/backend/src/Modules/Auth/Application/Services/UserAdminService.cs
+++ b/backend/src/Modules/Auth/Application/Services/UserAdminService.cs
@@ -1,0 +1,145 @@
+using IMS.Modular.Modules.Auth.Application.DTOs;
+using IMS.Modular.Modules.Auth.Domain.Entities;
+using IMS.Modular.Shared.Common;
+using Microsoft.EntityFrameworkCore;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace IMS.Modular.Modules.Auth.Application.Services;
+
+public interface IUserAdminService
+{
+    Task<PagedResult<UserAdminDto>> GetUsersAsync(int page, int pageSize, string? search, string? role, CancellationToken ct = default);
+    Task<UserAdminDto?> GetUserByIdAsync(Guid id, CancellationToken ct = default);
+    Task<IReadOnlyList<RoleDto>> GetRolesAsync(CancellationToken ct = default);
+    Task<bool> UpdateUserRoleAsync(Guid userId, string roleName, CancellationToken ct = default);
+    Task<bool> SetUserActiveAsync(Guid userId, bool isActive, CancellationToken ct = default);
+    Task<UserAdminDto?> InviteUserAsync(InviteUserRequest request, CancellationToken ct = default);
+}
+
+public sealed class UserAdminService(Infrastructure.AuthDbContext db) : IUserAdminService
+{
+    public async Task<PagedResult<UserAdminDto>> GetUsersAsync(
+        int page, int pageSize, string? search, string? role, CancellationToken ct = default)
+    {
+        var query = db.Users
+            .Include(u => u.UserRoles).ThenInclude(ur => ur.Role)
+            .AsNoTracking();
+
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            var s = search.ToLower();
+            query = query.Where(u =>
+                u.Username.ToLower().Contains(s) ||
+                u.Email.ToLower().Contains(s) ||
+                u.FullName.ToLower().Contains(s));
+        }
+
+        if (!string.IsNullOrWhiteSpace(role))
+            query = query.Where(u => u.UserRoles.Any(ur => ur.Role.Name == role));
+
+        var total = await query.CountAsync(ct);
+        var users = await query
+            .OrderBy(u => u.Username)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(ct);
+
+        return new PagedResult<UserAdminDto>(
+            [.. users.Select(ToDto)],
+            total,
+            page,
+            pageSize
+        );
+    }
+
+    public async Task<UserAdminDto?> GetUserByIdAsync(Guid id, CancellationToken ct = default)
+    {
+        var user = await db.Users
+            .Include(u => u.UserRoles).ThenInclude(ur => ur.Role)
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Id == id, ct);
+
+        return user is null ? null : ToDto(user);
+    }
+
+    public async Task<IReadOnlyList<RoleDto>> GetRolesAsync(CancellationToken ct = default)
+    {
+        return await db.Roles
+            .AsNoTracking()
+            .OrderBy(r => r.Name)
+            .Select(r => new RoleDto(r.Id.ToString(), r.Name, r.Description))
+            .ToListAsync(ct);
+    }
+
+    public async Task<bool> UpdateUserRoleAsync(Guid userId, string roleName, CancellationToken ct = default)
+    {
+        var user = await db.Users
+            .Include(u => u.UserRoles).ThenInclude(ur => ur.Role)
+            .FirstOrDefaultAsync(u => u.Id == userId, ct);
+        if (user is null) return false;
+
+        var newRole = await db.Roles.FirstOrDefaultAsync(r => r.Name == roleName, ct);
+        if (newRole is null) return false;
+
+        // Remove existing roles and assign the new one
+        db.UserRoles.RemoveRange(user.UserRoles);
+        user.UserRoles.Add(new UserRole { UserId = userId, RoleId = newRole.Id, Role = newRole });
+        await db.SaveChangesAsync(ct);
+        return true;
+    }
+
+    public async Task<bool> SetUserActiveAsync(Guid userId, bool isActive, CancellationToken ct = default)
+    {
+        var user = await db.Users.FindAsync([userId], ct);
+        if (user is null) return false;
+
+        user.IsActive = isActive;
+        if (!isActive) user.ClearRefreshToken();
+        await db.SaveChangesAsync(ct);
+        return true;
+    }
+
+    public async Task<UserAdminDto?> InviteUserAsync(InviteUserRequest request, CancellationToken ct = default)
+    {
+        if (await db.Users.AnyAsync(u => u.Username == request.Username || u.Email == request.Email, ct))
+            return null;
+
+        var password = request.TemporaryPassword ?? GenerateTemporaryPassword();
+        var user = new User
+        {
+            Username = request.Username,
+            Email = request.Email,
+            FullName = request.FullName,
+            PasswordHash = HashPassword(password),
+            IsActive = true
+        };
+
+        db.Users.Add(user);
+
+        var role = await db.Roles.FirstOrDefaultAsync(r => r.Name == request.Role, ct)
+                   ?? await db.Roles.FirstOrDefaultAsync(r => r.Name == "User", ct);
+
+        if (role is not null)
+            user.UserRoles.Add(new UserRole { UserId = user.Id, RoleId = role.Id, Role = role });
+
+        await db.SaveChangesAsync(ct);
+        return ToDto(user);
+    }
+
+    private static UserAdminDto ToDto(User u) =>
+        new(u.Id.ToString(), u.Username, u.Email, u.FullName,
+            u.UserRoles.Select(ur => ur.Role.Name).ToArray(),
+            u.IsActive, u.LastLoginAt, u.CreatedAt);
+
+    private static string HashPassword(string password) =>
+        Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(password)));
+
+    private static string GenerateTemporaryPassword()
+    {
+        const string chars = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789!@#$";
+        return new string(Enumerable.Range(0, 12)
+            .Select(_ => chars[RandomNumberGenerator.GetInt32(chars.Length)])
+            .ToArray());
+    }
+}

--- a/backend/src/Modules/Auth/Application/Validators/AuthValidators.cs
+++ b/backend/src/Modules/Auth/Application/Validators/AuthValidators.cs
@@ -43,3 +43,25 @@ public sealed class RegisterRequestValidator : AbstractValidator<RegisterRequest
             .Length(2, 200).WithMessage("Full name must be between 2 and 200 characters");
     }
 }
+
+// ── US-040 Admin Validators ────────────────────────────────────────────────────
+
+public sealed class UpdateUserRoleRequestValidator : AbstractValidator<UpdateUserRoleRequest>
+{
+    public UpdateUserRoleRequestValidator()
+    {
+        RuleFor(x => x.RoleName).NotEmpty().MaximumLength(50);
+    }
+}
+
+public sealed class InviteUserRequestValidator : AbstractValidator<InviteUserRequest>
+{
+    public InviteUserRequestValidator()
+    {
+        RuleFor(x => x.Username).NotEmpty().Length(3, 50)
+            .Matches("^[a-zA-Z0-9_]+$").WithMessage("Username can only contain letters, numbers, and underscores");
+        RuleFor(x => x.Email).NotEmpty().EmailAddress().MaximumLength(255);
+        RuleFor(x => x.FullName).NotEmpty().Length(2, 200);
+        RuleFor(x => x.Role).NotEmpty().MaximumLength(50);
+    }
+}

--- a/backend/src/Modules/Auth/AuthModuleExtensions.cs
+++ b/backend/src/Modules/Auth/AuthModuleExtensions.cs
@@ -23,6 +23,7 @@ public static class AuthModuleExtensions
         // Services
         services.AddSingleton<JwtTokenService>();
         services.AddScoped<IAuthenticationService, AuthenticationService>();
+        services.AddScoped<IUserAdminService, UserAdminService>();
 
         // JWT Authentication
         services.AddAuthentication(options =>
@@ -57,7 +58,11 @@ public static class AuthModuleExtensions
             };
         });
 
-        services.AddAuthorization();
+        services.AddAuthorization(options =>
+        {
+            options.AddPolicy("AdminOnly", policy =>
+                policy.RequireRole("Admin"));
+        });
 
         return services;
     }

--- a/backend/src/Program.cs
+++ b/backend/src/Program.cs
@@ -229,6 +229,7 @@ app.MapGet("/api/status", () => Results.Ok(new
 // ============================================================
 
 AuthModule.Map(app);
+UserAdminModule.Map(app);
 IssuesModule.Map(app);
 InventoryModule.Map(app);
 InventoryIssuesModule.Map(app);

--- a/frontend/apps/next-shell/app/(dashboard)/admin/layout.tsx
+++ b/frontend/apps/next-shell/app/(dashboard)/admin/layout.tsx
@@ -1,0 +1,23 @@
+/**
+ * Admin Layout — US-040
+ * Valida que o usuário tem role Admin.
+ * Redireciona para /dashboard se não for admin.
+ */
+
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/auth";
+
+export const metadata = { title: "Administração" };
+
+export default async function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const session = await getSession();
+  if (!session || !session.roles.includes("Admin")) {
+    redirect("/issues");
+  }
+
+  return <>{children}</>;
+}

--- a/frontend/apps/next-shell/app/(dashboard)/admin/users/page.tsx
+++ b/frontend/apps/next-shell/app/(dashboard)/admin/users/page.tsx
@@ -1,0 +1,51 @@
+/**
+ * Admin Users Page — US-040
+ *
+ * Server Component: busca dados iniciais de usuários e roles,
+ * repassa ao UsersClient para CRUD interativo.
+ * Requer autenticação com role Admin (guard no layout).
+ */
+
+import { apiFetch } from "@/lib/api-fetch";
+import type { PagedResult, UserAdminDto, RoleDto } from "@/lib/types";
+import { UsersClient } from "@/components/admin/users-client";
+
+export const metadata = { title: "Gerenciar Usuários" };
+
+interface SearchParams {
+  page?: string;
+  search?: string;
+  role?: string;
+}
+
+async function fetchUsers(params: SearchParams) {
+  const qs = new URLSearchParams({ page: params.page ?? "1", pageSize: "20" });
+  if (params.search) qs.set("search", params.search);
+  if (params.role) qs.set("role", params.role);
+  return apiFetch<PagedResult<UserAdminDto>>(`/api/admin/users?${qs}`).catch(
+    () => null
+  );
+}
+
+async function fetchRoles() {
+  return apiFetch<RoleDto[]>(`/api/admin/users/roles`).catch(() => []);
+}
+
+export default async function AdminUsersPage({
+  searchParams,
+}: {
+  searchParams: Promise<SearchParams>;
+}) {
+  const params = await searchParams;
+  const [data, roles] = await Promise.all([fetchUsers(params), fetchRoles()]);
+
+  return (
+    <div>
+      <UsersClient
+        initialData={data}
+        initialRoles={roles}
+        searchParams={params}
+      />
+    </div>
+  );
+}

--- a/frontend/apps/next-shell/app/(dashboard)/layout.tsx
+++ b/frontend/apps/next-shell/app/(dashboard)/layout.tsx
@@ -12,9 +12,11 @@ export default async function DashboardLayout({
   const session = await getSession();
   if (!session) redirect("/login");
 
+  const isAdmin = session.roles.includes("Admin");
+
   return (
-    <div className="flex h-screen overflow-hidden bg-gray-100">
-      <Sidebar />
+    <div className="flex h-screen overflow-hidden bg-(--bg-app)">
+      <Sidebar isAdmin={isAdmin} />
       <main className="flex-1 overflow-y-auto">
         <div className="p-6 max-w-7xl mx-auto">{children}</div>
       </main>

--- a/frontend/apps/next-shell/components/admin/change-role-dialog.tsx
+++ b/frontend/apps/next-shell/components/admin/change-role-dialog.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+/**
+ * ChangeRoleDialog — US-040
+ * Dialog para alterar a role de um usuário.
+ */
+
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { Dialog } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import type { RoleDto, UserAdminDto } from "@/lib/types";
+
+interface FormValues {
+  roleName: string;
+}
+
+interface Props {
+  open: boolean;
+  user: UserAdminDto | null;
+  roles: RoleDto[];
+  onClose: () => void;
+  onSubmit: (roleName: string) => Promise<void>;
+}
+
+export function ChangeRoleDialog({ open, user, roles, onClose, onSubmit }: Props) {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { isSubmitting },
+  } = useForm<FormValues>();
+
+  useEffect(() => {
+    if (user) reset({ roleName: user.roles[0] ?? "User" });
+  }, [user, reset]);
+
+  const handleFormSubmit = async (values: FormValues) => {
+    await onSubmit(values.roleName);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title="Alterar role"
+      description={user ? `Usuário: ${user.username}` : undefined}
+      size="sm"
+      footer={
+        <>
+          <Button variant="secondary" onClick={onClose}>
+            Cancelar
+          </Button>
+          <Button type="submit" form="role-form" loading={isSubmitting}>
+            Salvar
+          </Button>
+        </>
+      }
+    >
+      <form id="role-form" onSubmit={handleSubmit(handleFormSubmit)}>
+        <label className="block text-sm font-medium text-(--text-primary) mb-2">
+          Nova role
+        </label>
+        <select
+          {...register("roleName")}
+          className="w-full px-3 py-2 rounded-lg border border-(--border-input) bg-(--bg-surface) text-(--text-primary) text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          {roles.map((r) => (
+            <option key={r.id} value={r.name}>
+              {r.name}
+              {r.description ? ` — ${r.description}` : ""}
+            </option>
+          ))}
+        </select>
+      </form>
+    </Dialog>
+  );
+}

--- a/frontend/apps/next-shell/components/admin/invite-user-dialog.tsx
+++ b/frontend/apps/next-shell/components/admin/invite-user-dialog.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+/**
+ * InviteUserDialog — US-040
+ * Dialog para convidar novo usuário com username, email, nome e role.
+ */
+
+import { useEffect } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Dialog } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import type { RoleDto } from "@/lib/types";
+
+const schema = z.object({
+  username: z
+    .string()
+    .min(3, "Mínimo 3 caracteres")
+    .max(50)
+    .regex(/^[a-zA-Z0-9_]+$/, "Apenas letras, números e _"),
+  email: z.string().email("E-mail inválido").max(255),
+  fullName: z.string().min(2, "Nome obrigatório").max(200),
+  role: z.string().min(1, "Role obrigatória"),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+interface Props {
+  open: boolean;
+  roles: RoleDto[];
+  onClose: () => void;
+  onSubmit: (data: FormValues) => Promise<void>;
+}
+
+export function InviteUserDialog({ open, roles, onClose, onSubmit }: Props) {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { role: "User" },
+  });
+
+  useEffect(() => {
+    if (open) reset({ role: "User" });
+  }, [open, reset]);
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title="Convidar usuário"
+      description="O usuário receberá uma senha temporária gerada automaticamente."
+      size="sm"
+      footer={
+        <>
+          <Button variant="secondary" onClick={onClose}>
+            Cancelar
+          </Button>
+          <Button
+            type="submit"
+            form="invite-form"
+            loading={isSubmitting}
+          >
+            Convidar
+          </Button>
+        </>
+      }
+    >
+      <form
+        id="invite-form"
+        onSubmit={handleSubmit(onSubmit)}
+        className="space-y-4"
+      >
+        <div>
+          <label className="block text-sm font-medium text-(--text-primary) mb-1">
+            Nome completo <span className="text-red-500">*</span>
+          </label>
+          <input
+            {...register("fullName")}
+            placeholder="João da Silva"
+            className="w-full px-3 py-2 rounded-lg border border-(--border-input) bg-(--bg-surface) text-(--text-primary) text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          {errors.fullName && (
+            <p className="mt-1 text-xs text-red-500">{errors.fullName.message}</p>
+          )}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-(--text-primary) mb-1">
+            Username <span className="text-red-500">*</span>
+          </label>
+          <input
+            {...register("username")}
+            placeholder="joao.silva"
+            className="w-full px-3 py-2 rounded-lg border border-(--border-input) bg-(--bg-surface) text-(--text-primary) text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          {errors.username && (
+            <p className="mt-1 text-xs text-red-500">{errors.username.message}</p>
+          )}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-(--text-primary) mb-1">
+            E-mail <span className="text-red-500">*</span>
+          </label>
+          <input
+            {...register("email")}
+            type="email"
+            placeholder="joao@empresa.com"
+            className="w-full px-3 py-2 rounded-lg border border-(--border-input) bg-(--bg-surface) text-(--text-primary) text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          {errors.email && (
+            <p className="mt-1 text-xs text-red-500">{errors.email.message}</p>
+          )}
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-(--text-primary) mb-1">
+            Role <span className="text-red-500">*</span>
+          </label>
+          <select
+            {...register("role")}
+            className="w-full px-3 py-2 rounded-lg border border-(--border-input) bg-(--bg-surface) text-(--text-primary) text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            {roles.map((r) => (
+              <option key={r.id} value={r.name}>
+                {r.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      </form>
+    </Dialog>
+  );
+}

--- a/frontend/apps/next-shell/components/admin/users-client.tsx
+++ b/frontend/apps/next-shell/components/admin/users-client.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+/**
+ * UsersClient — US-040
+ *
+ * Componente client-side para gerenciamento de usuários (admin).
+ * Funcionalidades: listar, filtrar, convidar, alterar role, ativar/desativar.
+ */
+
+import { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { UserPlus, ShieldCheck, UserX, UserCheck, Search } from "lucide-react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { InviteUserDialog } from "@/components/admin/invite-user-dialog";
+import { ChangeRoleDialog } from "@/components/admin/change-role-dialog";
+import {
+  getAdminUsers,
+  getRoles,
+  inviteUser,
+  updateUserRole,
+  activateUser,
+  deactivateUser,
+} from "@/lib/api/users";
+import type {
+  UserAdminDto,
+  RoleDto,
+  InviteUserRequest,
+  PagedResult,
+} from "@/lib/types";
+
+interface Props {
+  initialData: PagedResult<UserAdminDto> | null;
+  initialRoles: RoleDto[];
+  searchParams: { page?: string; search?: string; role?: string };
+}
+
+export function UsersClient({ initialData, initialRoles, searchParams }: Props) {
+  const router = useRouter();
+  const [data, setData] = useState(initialData);
+  const [roles] = useState<RoleDto[]>(initialRoles);
+
+  const [inviteOpen, setInviteOpen] = useState(false);
+  const [roleOpen, setRoleOpen] = useState(false);
+  const [selectedUser, setSelectedUser] = useState<UserAdminDto | null>(null);
+
+  const [search, setSearch] = useState(searchParams.search ?? "");
+  const [roleFilter, setRoleFilter] = useState(searchParams.role ?? "");
+
+  const refresh = useCallback(async (page = 1, s = search, r = roleFilter) => {
+    try {
+      const fresh = await getAdminUsers({ page, pageSize: 20, search: s || undefined, role: r || undefined });
+      setData(fresh);
+    } catch {
+      toast.error("Erro ao atualizar lista de usuários");
+    }
+  }, [search, roleFilter]);
+
+  // ── Invite ─────────────────────────────────────────────────────────────
+  const handleInvite = async (values: InviteUserRequest) => {
+    await inviteUser(values);
+    toast.success(`Usuário ${values.username} convidado com sucesso!`);
+    setInviteOpen(false);
+    await refresh();
+  };
+
+  // ── Change Role ────────────────────────────────────────────────────────
+  const openRoleChange = (user: UserAdminDto) => {
+    setSelectedUser(user);
+    setRoleOpen(true);
+  };
+
+  const handleRoleChange = async (roleName: string) => {
+    if (!selectedUser) return;
+    await updateUserRole(selectedUser.id, roleName);
+    toast.success(`Role de ${selectedUser.username} atualizada para ${roleName}`);
+    setRoleOpen(false);
+    setSelectedUser(null);
+    await refresh();
+  };
+
+  // ── Activate / Deactivate ───────────────────────────────────────────────
+  const handleToggleActive = async (user: UserAdminDto) => {
+    if (user.isActive) {
+      await deactivateUser(user.id);
+      toast.success(`${user.username} desativado`);
+    } else {
+      await activateUser(user.id);
+      toast.success(`${user.username} ativado`);
+    }
+    await refresh();
+  };
+
+  // ── Filter ─────────────────────────────────────────────────────────────
+  const applyFilter = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const qs = new URLSearchParams();
+    if (search) qs.set("search", search);
+    if (roleFilter) qs.set("role", roleFilter);
+    router.push(`/admin/users?${qs}`);
+    await refresh(1, search, roleFilter);
+  };
+
+  return (
+    <>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-(--text-primary)">Usuários</h1>
+          <p className="text-(--text-secondary) text-sm mt-0.5">
+            {data ? `${data.totalCount} usuários cadastrados` : "Carregando..."}
+          </p>
+        </div>
+        <Button onClick={() => setInviteOpen(true)}>
+          <UserPlus size={16} />
+          Convidar usuário
+        </Button>
+      </div>
+
+      {/* Filtros */}
+      <form onSubmit={applyFilter} className="flex flex-wrap gap-3 mb-5">
+        <div className="flex-1 min-w-48 relative">
+          <Search size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-(--text-muted)" />
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Buscar por nome, username, e-mail..."
+            className="w-full pl-9 pr-3 py-2 rounded-lg border border-(--border-input) bg-(--bg-surface) text-(--text-primary) text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <select
+          value={roleFilter}
+          onChange={(e) => setRoleFilter(e.target.value)}
+          className="px-3 py-2 rounded-lg border border-(--border-input) bg-(--bg-surface) text-(--text-primary) text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          <option value="">Todas as roles</option>
+          {roles.map((r) => (
+            <option key={r.id} value={r.name}>{r.name}</option>
+          ))}
+        </select>
+        <Button type="submit" variant="secondary">Filtrar</Button>
+      </form>
+
+      {/* Tabela */}
+      {!data ? (
+        <Card>
+          <p className="text-center text-(--text-secondary) py-4">
+            Erro ao carregar usuários.
+          </p>
+        </Card>
+      ) : data.items.length === 0 ? (
+        <Card>
+          <p className="text-center text-(--text-secondary) py-8">
+            Nenhum usuário encontrado.
+          </p>
+        </Card>
+      ) : (
+        <div className="bg-(--bg-surface) border border-(--border) rounded-xl overflow-hidden shadow-sm">
+          <table className="w-full text-sm">
+            <thead className="bg-(--bg-subtle) border-b border-(--border)">
+              <tr>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-(--text-secondary) uppercase tracking-wide">
+                  Usuário
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-(--text-secondary) uppercase tracking-wide">
+                  Roles
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-(--text-secondary) uppercase tracking-wide">
+                  Status
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-semibold text-(--text-secondary) uppercase tracking-wide">
+                  Último acesso
+                </th>
+                <th className="px-4 py-3" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-(--border)">
+              {data.items.map((user) => (
+                <tr key={user.id} className="hover:bg-(--bg-subtle) transition-colors">
+                  <td className="px-4 py-3">
+                    <div className="font-medium text-(--text-primary)">{user.fullName}</div>
+                    <div className="text-xs text-(--text-muted)">
+                      @{user.username} · {user.email}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex flex-wrap gap-1">
+                      {user.roles.map((role) => (
+                        <Badge
+                          key={role}
+                          variant={role === "Admin" ? "purple" : "info"}
+                        >
+                          {role}
+                        </Badge>
+                      ))}
+                    </div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <Badge variant={user.isActive ? "success" : "default"}>
+                      {user.isActive ? "Ativo" : "Inativo"}
+                    </Badge>
+                  </td>
+                  <td className="px-4 py-3 text-(--text-secondary)">
+                    {user.lastLoginAt
+                      ? new Date(user.lastLoginAt).toLocaleString("pt-BR")
+                      : "—"}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex items-center justify-end gap-1">
+                      <button
+                        onClick={() => openRoleChange(user)}
+                        title="Alterar role"
+                        className="p-1.5 rounded-lg text-(--text-muted) hover:text-purple-600 hover:bg-purple-50 dark:hover:bg-purple-900/30 transition-colors"
+                      >
+                        <ShieldCheck size={15} />
+                      </button>
+                      <button
+                        onClick={() => handleToggleActive(user)}
+                        title={user.isActive ? "Desativar" : "Ativar"}
+                        className={`p-1.5 rounded-lg transition-colors ${
+                          user.isActive
+                            ? "text-(--text-muted) hover:text-red-600 hover:bg-red-50 dark:hover:bg-red-900/30"
+                            : "text-(--text-muted) hover:text-green-600 hover:bg-green-50 dark:hover:bg-green-900/30"
+                        }`}
+                      >
+                        {user.isActive ? <UserX size={15} /> : <UserCheck size={15} />}
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {/* Paginação */}
+          <div className="px-4 py-3 border-t border-(--border) flex items-center justify-between text-sm text-(--text-secondary)">
+            <span>
+              Página {data.pageNumber} de {data.totalPages}
+            </span>
+            <div className="flex gap-2">
+              {data.pageNumber > 1 && (
+                <button
+                  onClick={() => refresh(data.pageNumber - 1)}
+                  className="px-3 py-1 rounded border border-(--border) hover:bg-(--bg-subtle)"
+                >
+                  Anterior
+                </button>
+              )}
+              {data.pageNumber < data.totalPages && (
+                <button
+                  onClick={() => refresh(data.pageNumber + 1)}
+                  className="px-3 py-1 rounded border border-(--border) hover:bg-(--bg-subtle)"
+                >
+                  Próxima
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Dialogs */}
+      <InviteUserDialog
+        open={inviteOpen}
+        roles={roles}
+        onClose={() => setInviteOpen(false)}
+        onSubmit={handleInvite}
+      />
+
+      <ChangeRoleDialog
+        open={roleOpen}
+        user={selectedUser}
+        roles={roles}
+        onClose={() => { setRoleOpen(false); setSelectedUser(null); }}
+        onSubmit={handleRoleChange}
+      />
+    </>
+  );
+}

--- a/frontend/apps/next-shell/components/sidebar.tsx
+++ b/frontend/apps/next-shell/components/sidebar.tsx
@@ -11,6 +11,7 @@ import {
   LogOut,
   Menu,
   X,
+  Users,
 } from "lucide-react";
 import { useState } from "react";
 import { useTranslations } from "next-intl";
@@ -18,7 +19,7 @@ import { cn } from "@/lib/utils";
 import { LocaleSwitcher } from "./locale-switcher";
 import { broadcastLogout } from "@/lib/session-sync";
 
-export function Sidebar() {
+export function Sidebar({ isAdmin = false }: { isAdmin?: boolean }) {
   const pathname = usePathname();
   const router = useRouter();
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -30,6 +31,9 @@ export function Sidebar() {
     { href: "/issues", label: t("issues"), icon: AlertCircle },
     { href: "/inventory", label: t("inventory"), icon: Package },
     { href: "/analytics", label: t("analytics"), icon: BarChart3 },
+    ...(isAdmin
+      ? [{ href: "/admin/users", label: t("users"), icon: Users }]
+      : []),
   ];
 
   const handleLogout = async () => {

--- a/frontend/apps/next-shell/components/ui/badge.tsx
+++ b/frontend/apps/next-shell/components/ui/badge.tsx
@@ -1,0 +1,53 @@
+/**
+ * ui/badge.tsx — US-041
+ * Badge genérico com variantes de cor e suporte a dark mode.
+ */
+
+import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
+
+export type BadgeVariant =
+  | "default"
+  | "success"
+  | "warning"
+  | "danger"
+  | "info"
+  | "purple"
+  | "orange";
+
+const variantClass: Record<BadgeVariant, string> = {
+  default: "bg-gray-100 text-gray-600 border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-700",
+  success: "bg-green-100 text-green-700 border-green-200 dark:bg-green-900/40 dark:text-green-400 dark:border-green-800",
+  warning: "bg-yellow-100 text-yellow-700 border-yellow-200 dark:bg-yellow-900/40 dark:text-yellow-400 dark:border-yellow-800",
+  danger:  "bg-red-100 text-red-700 border-red-200 dark:bg-red-900/40 dark:text-red-400 dark:border-red-800",
+  info:    "bg-blue-100 text-blue-700 border-blue-200 dark:bg-blue-900/40 dark:text-blue-400 dark:border-blue-800",
+  purple:  "bg-purple-100 text-purple-700 border-purple-200 dark:bg-purple-900/40 dark:text-purple-400 dark:border-purple-800",
+  orange:  "bg-orange-100 text-orange-700 border-orange-200 dark:bg-orange-900/40 dark:text-orange-400 dark:border-orange-800",
+};
+
+interface BadgeProps {
+  variant?: BadgeVariant;
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * Badge genérico com suporte a dark mode.
+ *
+ * @example
+ * <Badge variant="success">Ativo</Badge>
+ * <Badge variant="danger">Inativo</Badge>
+ */
+export function Badge({ variant = "default", children, className }: BadgeProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium border",
+        variantClass[variant],
+        className
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/frontend/apps/next-shell/components/ui/button.tsx
+++ b/frontend/apps/next-shell/components/ui/button.tsx
@@ -1,0 +1,71 @@
+/**
+ * ui/button.tsx — US-041
+ * Botão base genérico com variantes e suporte a dark mode.
+ */
+
+import { cn } from "@/lib/utils";
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
+export type ButtonVariant = "primary" | "secondary" | "danger" | "ghost";
+export type ButtonSize = "sm" | "md" | "lg";
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  children: ReactNode;
+  loading?: boolean;
+}
+
+const variantClasses: Record<ButtonVariant, string> = {
+  primary:
+    "bg-blue-600 text-white hover:bg-blue-500 focus-visible:ring-blue-500",
+  secondary:
+    "bg-(--bg-surface) text-(--text-primary) border border-(--border) hover:bg-(--bg-subtle)",
+  danger:
+    "bg-red-600 text-white hover:bg-red-500 focus-visible:ring-red-500",
+  ghost:
+    "text-(--text-secondary) hover:text-(--text-primary) hover:bg-(--bg-subtle)",
+};
+
+const sizeClasses: Record<ButtonSize, string> = {
+  sm: "px-3 py-1.5 text-xs",
+  md: "px-4 py-2 text-sm",
+  lg: "px-5 py-2.5 text-base",
+};
+
+/**
+ * Button genérico com variantes e tamanhos.
+ *
+ * @example
+ * <Button variant="primary" onClick={save}>Salvar</Button>
+ * <Button variant="danger" size="sm">Excluir</Button>
+ */
+export function Button({
+  variant = "primary",
+  size = "md",
+  loading,
+  disabled,
+  className,
+  children,
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      disabled={disabled || loading}
+      className={cn(
+        "inline-flex items-center justify-center gap-2 rounded-lg font-medium transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2",
+        "disabled:opacity-50 disabled:cursor-not-allowed",
+        variantClasses[variant],
+        sizeClasses[size],
+        className
+      )}
+      {...props}
+    >
+      {loading ? (
+        <span className="h-4 w-4 rounded-full border-2 border-current border-t-transparent animate-spin" />
+      ) : null}
+      {children}
+    </button>
+  );
+}

--- a/frontend/apps/next-shell/components/ui/card.tsx
+++ b/frontend/apps/next-shell/components/ui/card.tsx
@@ -1,0 +1,46 @@
+/**
+ * ui/card.tsx — US-041
+ * Card base genérico com suporte a dark mode via CSS vars.
+ */
+
+import { cn } from "@/lib/utils";
+import type { ReactNode } from "react";
+
+interface CardProps {
+  children: ReactNode;
+  className?: string;
+  padding?: boolean;
+}
+
+/** Card surface com bordas e sombra, responde ao tema dark/light automaticamente. */
+export function Card({ children, className, padding = true }: CardProps) {
+  return (
+    <div
+      className={cn(
+        "bg-(--bg-surface) border border-(--border) rounded-xl shadow-sm",
+        padding && "p-5",
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+/** Cabeçalho de Card com título e slot opcional de ação */
+export function CardHeader({
+  title,
+  action,
+  className,
+}: {
+  title: string;
+  action?: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={cn("flex items-center justify-between mb-4", className)}>
+      <h2 className="text-sm font-semibold text-(--text-primary)">{title}</h2>
+      {action}
+    </div>
+  );
+}

--- a/frontend/apps/next-shell/components/ui/dialog.tsx
+++ b/frontend/apps/next-shell/components/ui/dialog.tsx
@@ -1,0 +1,92 @@
+/**
+ * ui/dialog.tsx — US-041
+ * Dialog base genérico com suporte a dark mode via CSS vars.
+ */
+
+"use client";
+
+import { useEffect, useRef, type ReactNode } from "react";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface DialogProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  description?: string;
+  children: ReactNode;
+  footer?: ReactNode;
+  size?: "sm" | "md" | "lg";
+}
+
+const sizeClass = {
+  sm: "max-w-sm",
+  md: "max-w-2xl",
+  lg: "max-w-4xl",
+};
+
+/**
+ * Dialog base reutilizável com suporte a dark mode.
+ * Usa `<dialog>` nativo para acessibilidade (foco trap, Esc para fechar).
+ *
+ * @example
+ * <Dialog open={open} onClose={close} title="Novo item">
+ *   <p>Conteúdo</p>
+ * </Dialog>
+ */
+export function Dialog({
+  open,
+  onClose,
+  title,
+  description,
+  children,
+  footer,
+  size = "md",
+}: DialogProps) {
+  const ref = useRef<HTMLDialogElement>(null);
+
+  useEffect(() => {
+    if (open) ref.current?.showModal();
+    else ref.current?.close();
+  }, [open]);
+
+  return (
+    <dialog
+      ref={ref}
+      onClose={onClose}
+      className={cn(
+        "w-full rounded-xl shadow-xl p-0 bg-(--bg-surface) text-(--text-primary)",
+        "backdrop:bg-black/50",
+        "open:flex open:flex-col",
+        sizeClass[size]
+      )}
+    >
+      {/* Header */}
+      <div className="flex items-start justify-between px-6 py-4 border-b border-(--border) shrink-0">
+        <div>
+          <h2 className="text-lg font-semibold text-(--text-primary)">{title}</h2>
+          {description && (
+            <p className="text-sm text-(--text-secondary) mt-0.5">{description}</p>
+          )}
+        </div>
+        <button
+          onClick={onClose}
+          aria-label="Fechar"
+          className="p-1.5 rounded-lg text-(--text-muted) hover:text-(--text-primary) hover:bg-(--bg-subtle) transition-colors"
+        >
+          <X size={18} />
+        </button>
+      </div>
+
+      {/* Body */}
+      <div className="overflow-y-auto max-h-[75vh] px-6 py-5">{children}</div>
+
+      {/* Footer */}
+      {footer && (
+        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-(--border) bg-(--bg-subtle) shrink-0">
+          {footer}
+        </div>
+      )}
+    </dialog>
+  );
+}

--- a/frontend/apps/next-shell/components/ui/index.ts
+++ b/frontend/apps/next-shell/components/ui/index.ts
@@ -1,0 +1,12 @@
+/**
+ * components/ui/index.ts — US-041
+ * Barrel export de todos os componentes UI base.
+ */
+
+export { Card, CardHeader } from "./card";
+export { Button } from "./button";
+export type { ButtonVariant, ButtonSize } from "./button";
+export { Input, Textarea, Select } from "./input";
+export { Dialog } from "./dialog";
+export { Badge } from "./badge";
+export type { BadgeVariant } from "./badge";

--- a/frontend/apps/next-shell/components/ui/input.tsx
+++ b/frontend/apps/next-shell/components/ui/input.tsx
@@ -1,0 +1,92 @@
+/**
+ * ui/input.tsx — US-041
+ * Input e Textarea base com suporte a dark mode.
+ */
+
+import { cn } from "@/lib/utils";
+import type { InputHTMLAttributes, TextareaHTMLAttributes } from "react";
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  error?: string;
+}
+
+interface TextareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  label?: string;
+  error?: string;
+}
+
+const baseInputClass =
+  "w-full px-3 py-2 rounded-lg border border-(--border-input) bg-(--bg-surface) text-(--text-primary) " +
+  "text-sm placeholder:text-(--text-muted) " +
+  "focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 " +
+  "disabled:opacity-50 disabled:cursor-not-allowed transition-colors";
+
+/** Input base com label e mensagem de erro. */
+export function Input({ label, error, className, id, ...props }: InputProps) {
+  return (
+    <div className="space-y-1">
+      {label && (
+        <label htmlFor={id} className="block text-sm font-medium text-(--text-primary)">
+          {label}
+        </label>
+      )}
+      <input id={id} className={cn(baseInputClass, className)} {...props} />
+      {error && <p className="text-xs text-red-500">{error}</p>}
+    </div>
+  );
+}
+
+/** Textarea base com label e mensagem de erro. */
+export function Textarea({ label, error, className, id, ...props }: TextareaProps) {
+  return (
+    <div className="space-y-1">
+      {label && (
+        <label htmlFor={id} className="block text-sm font-medium text-(--text-primary)">
+          {label}
+        </label>
+      )}
+      <textarea
+        id={id}
+        className={cn(baseInputClass, "resize-none", className)}
+        {...props}
+      />
+      {error && <p className="text-xs text-red-500">{error}</p>}
+    </div>
+  );
+}
+
+/** Select base com label e mensagem de erro. */
+export function Select({
+  label,
+  error,
+  className,
+  id,
+  children,
+  ...props
+}: InputHTMLAttributes<HTMLSelectElement> & {
+  label?: string;
+  error?: string;
+}) {
+  return (
+    <div className="space-y-1">
+      {label && (
+        <label htmlFor={id} className="block text-sm font-medium text-(--text-primary)">
+          {label}
+        </label>
+      )}
+      <select
+        id={id}
+        className={cn(
+          baseInputClass,
+          "appearance-none cursor-pointer",
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </select>
+      {error && <p className="text-xs text-red-500">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/apps/next-shell/lib/api/users.ts
+++ b/frontend/apps/next-shell/lib/api/users.ts
@@ -1,0 +1,63 @@
+/**
+ * lib/api/users.ts — US-040
+ *
+ * Funções client-side para o módulo de admin de usuários.
+ * Usa apiFetch (api-client.ts) com interceptor de refresh token.
+ * Todas as chamadas passam pelo BFF proxy: /api/proxy/admin/users
+ */
+
+import { apiFetch } from "@/lib/api-client";
+import type {
+  UserAdminDto,
+  RoleDto,
+  InviteUserRequest,
+  PagedResult,
+} from "@/lib/types";
+
+const BASE = "/api/proxy/admin/users";
+
+export interface GetUsersParams {
+  page?: number;
+  pageSize?: number;
+  search?: string;
+  role?: string;
+}
+
+export function getAdminUsers(params: GetUsersParams = {}) {
+  const qs = new URLSearchParams();
+  if (params.page) qs.set("page", String(params.page));
+  if (params.pageSize) qs.set("pageSize", String(params.pageSize));
+  if (params.search) qs.set("search", params.search);
+  if (params.role) qs.set("role", params.role);
+  return apiFetch<PagedResult<UserAdminDto>>(`${BASE}?${qs}`);
+}
+
+export function getAdminUserById(id: string) {
+  return apiFetch<UserAdminDto>(`${BASE}/${id}`);
+}
+
+export function getRoles() {
+  return apiFetch<RoleDto[]>(`${BASE}/roles`);
+}
+
+export function updateUserRole(userId: string, roleName: string) {
+  return apiFetch<void>(`${BASE}/${userId}/role`, {
+    method: "PATCH",
+    body: JSON.stringify({ roleName }),
+  });
+}
+
+export function activateUser(userId: string) {
+  return apiFetch<void>(`${BASE}/${userId}/activate`, { method: "PATCH" });
+}
+
+export function deactivateUser(userId: string) {
+  return apiFetch<void>(`${BASE}/${userId}/deactivate`, { method: "PATCH" });
+}
+
+export function inviteUser(data: InviteUserRequest) {
+  return apiFetch<UserAdminDto>(`${BASE}/invite`, {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}

--- a/frontend/apps/next-shell/lib/types.ts
+++ b/frontend/apps/next-shell/lib/types.ts
@@ -215,3 +215,33 @@ export interface AnalyticsSummaryDto {
   issuesByPriority: Record<IssuePriority, number>;
   issuesByDay: { date: string; count: number }[];
 }
+
+// ─── Admin / Users ────────────────────────────────────────────────────────────
+
+export interface UserAdminDto {
+  id: string;
+  username: string;
+  email: string;
+  fullName: string;
+  roles: string[];
+  isActive: boolean;
+  lastLoginAt?: string;
+  createdAt: string;
+}
+
+export interface RoleDto {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+export interface InviteUserRequest {
+  username: string;
+  email: string;
+  fullName: string;
+  role: string;
+}
+
+export interface UpdateUserRoleRequest {
+  roleName: string;
+}

--- a/frontend/apps/next-shell/messages/en.json
+++ b/frontend/apps/next-shell/messages/en.json
@@ -59,6 +59,7 @@
     "issues": "Issues",
     "inventory": "Inventory",
     "analytics": "Analytics",
+    "users": "Users",
     "logout": "Sign out",
     "openMenu": "Open menu",
     "closeMenu": "Close menu"

--- a/frontend/apps/next-shell/messages/pt.json
+++ b/frontend/apps/next-shell/messages/pt.json
@@ -59,6 +59,7 @@
     "issues": "Issues",
     "inventory": "Inventário",
     "analytics": "Analytics",
+    "users": "Usuários",
     "logout": "Sair",
     "openMenu": "Abrir menu",
     "closeMenu": "Fechar menu"


### PR DESCRIPTION
## US-040 — User Management Frontend

### Resumo
Implementa gerenciamento de usuários completo: backend com endpoints de admin e frontend com listagem, convite, alteração de role e ativar/desativar.

### Backend — novos endpoints `/api/admin/users`

| Endpoint | Descrição |
|---|---|
| `GET /api/admin/users` | Listagem paginada com filtro de busca e role |
| `GET /api/admin/users/{id}` | Detalhe do usuário |
| `GET /api/admin/users/roles` | Lista de roles disponíveis |
| `PATCH /api/admin/users/{id}/role` | Alterar role |
| `PATCH /api/admin/users/{id}/activate` | Ativar usuário |
| `PATCH /api/admin/users/{id}/deactivate` | Desativar (bloqueia auto-desativação) |
| `POST /api/admin/users/invite` | Convidar novo usuário com senha temporária |

Todos os endpoints requerem política `AdminOnly` (role Admin).

### Frontend

- `lib/api/users.ts` — funções client-side via `apiFetch` com refresh token
- `components/admin/invite-user-dialog.tsx` — dialog de convite com validação zod+rhf
- `components/admin/change-role-dialog.tsx` — dialog de alteração de role
- `components/admin/users-client.tsx` — tabela com filtros, paginação, ações de role e ativar/desativar
- `app/(dashboard)/admin/layout.tsx` — guard de role Admin (redirect para /issues se não admin)
- `app/(dashboard)/admin/users/page.tsx` — Server Component SSR + UsersClient
- `components/sidebar.tsx` — link "Usuários" visível apenas para admins via prop `isAdmin`
- `app/(dashboard)/layout.tsx` — passa `isAdmin` ao Sidebar
- `messages/pt.json` + `messages/en.json` — chave `nav.users`

### Nota sobre componentes UI
Inclui `components/ui/` (card, button, dialog, badge) cherry-picked da US-041 para evitar dependência de merge order.

### Checklist
- [x] `npm run typecheck` passa sem erros
- [x] `npm run build` passa sem erros
- [x] `dotnet build` passa sem erros
- [x] `git rebase origin/main` feito antes do push
- [x] Sem `console.log` de debug

Closes #55