### PR TITLE
fix: analytics dashboard e integração Blazor WASM no Next.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,13 +162,15 @@ ims-modular/
 
 ## Tech Stack
 
+### Backend
+
 | Category | Technology | Version |
 |----------|-----------|---------|
 | Runtime | .NET | 9.0 |
 | Framework | ASP.NET Core Minimal API | 9.x |
 | ORM (Write) | Entity Framework Core | 9.x |
 | Data Access (Read) | Dapper | 2.x |
-| Database | SQLite (dev) / PostgreSQL (prod) | — |
+| Database | PostgreSQL 16 | 16.x |
 | CQRS | MediatR | 12.x |
 | Validation | FluentValidation | 11.x |
 | Auth | JWT Bearer (Microsoft.AspNetCore.Authentication.JwtBearer) | 9.x |
@@ -184,6 +186,22 @@ ims-modular/
 | Output Caching | ASP.NET Core Output Caching | 9.x |
 | API Docs | Swashbuckle (Swagger) | 7.x |
 
+### Frontend
+
+| Category | Technology | Version |
+|----------|-----------|---------|
+| Shell | Next.js (App Router) | 15.x |
+| Language | TypeScript | 5.x (strict) |
+| Styling | Tailwind CSS | 4.x |
+| UI Components | Radix UI / shadcn | — |
+| Forms | react-hook-form + zod | — |
+| i18n | next-intl | — |
+| Dark Mode | next-themes | — |
+| Real-Time | @microsoft/signalr | — |
+| Micro-Frontend | Blazor WASM (Custom Elements) | .NET 9 |
+| Component Library | MudBlazor | — |
+| E2E Tests | Playwright | — |
+
 ---
 
 ## Getting Started
@@ -191,64 +209,54 @@ ims-modular/
 ### Prerequisites
 
 - [.NET 9 SDK](https://dotnet.microsoft.com/download/dotnet/9.0)
+- [Node.js 20 LTS](https://nodejs.org/)
 - A terminal (bash, zsh, PowerShell)
-- [Docker](https://www.docker.com/) (optional, for full-stack local dev)
+- [Docker](https://www.docker.com/) (recommended, for full-stack local dev)
 
-### Run (local — SQLite, sem Docker)
-
-```bash
-cd src
-dotnet restore
-dotnet build
-dotnet run --urls http://localhost:5049
-```
-
-The API will be available at **http://localhost:5049**.
-
-Swagger UI: **http://localhost:5049**
-
-### Run (local — com Docker Compose: RabbitMQ + Redis)
+### ▶️ Quick Start (Docker — recommended)
 
 ```bash
-# Sobe RabbitMQ + Redis para desenvolvimento
-docker compose -f docker-compose.dev.yml up -d
+# 1. Clone and enter the repo
+git clone https://github.com/peleverton/ims-monolith.git
+cd ims-monolith
 
-# Roda a aplicação em modo Development (SQLite)
-dotnet run --project src/ims-monolith.csproj --urls http://localhost:5049
-```
-
-### Deploy (full-stack com Docker Compose)
-
-```bash
-# 1. Configure as variáveis de ambiente
-cp .env.example .env
-# edite .env com suas credenciais
-
-# 2. Suba toda a stack (app + PostgreSQL + Redis + RabbitMQ)
+# 2. Start the full stack
 docker compose up -d
+```
 
-# 3. Overlay opcional de observabilidade (Prometheus + Grafana)
+| Service | URL |
+|---------|-----|
+| **Frontend (Next.js)** | http://localhost:3000 |
+| **API (.NET)** | http://localhost:8080 |
+| Swagger UI | http://localhost:8080/swagger |
+| PostgreSQL | localhost:5432 |
+| Redis | localhost:6379 |
+| RabbitMQ UI | http://localhost:15672 (ims / ims) |
+
+> Default login: `admin@ims.com` / `Admin@123`
+
+### (Optional) With Observability
+
+```bash
 docker compose -f docker-compose.yml -f docker-compose.observability.yml up -d
 ```
 
-| Serviço | URL |
-|---|---|
-| API | http://localhost:8080 |
-| Swagger | http://localhost:8080/swagger |
-| RabbitMQ UI | http://localhost:15672 |
-| Grafana | http://localhost:3000 |
-| Prometheus | http://localhost:9090 |
+Adds Prometheus (`http://localhost:9090`) and Grafana (`http://localhost:3001`).
 
+### Run (local — without Docker)
 
-dotnet build
-dotnet run
+Requires PostgreSQL, Redis, and RabbitMQ running locally (or via `docker compose -f docker-compose.dev.yml up -d`).
+
+```bash
+# Backend
+cd backend/src
+dotnet restore && dotnet run --urls http://localhost:5049
+
+# Frontend (another terminal)
+cd frontend/apps/next-shell
+npm install
+npm run dev          # builds Blazor WASM then starts Next.js
 ```
-
-The API will be available at **http://localhost:5049**.
-
-Swagger UI: **http://localhost:5049/swagger**
-
-### Quick Smoke Test
 
 ```bash
 # Health check

--- a/backend/src/Modules/Analytics/Infrastructure/AnalyticsReadRepository.cs
+++ b/backend/src/Modules/Analytics/Infrastructure/AnalyticsReadRepository.cs
@@ -51,57 +51,37 @@ public class AnalyticsReadRepository(IDbConnection connection) : IAnalyticsReadR
     {
         const string sql = """
             SELECT
-                COUNT(*) AS Total,
-                SUM(CASE WHEN Status = 'Open' THEN 1 ELSE 0 END) AS Open,
-                SUM(CASE WHEN Status = 'InProgress' THEN 1 ELSE 0 END) AS InProgress,
-                SUM(CASE WHEN Status = 'Testing' THEN 1 ELSE 0 END) AS Testing,
-                SUM(CASE WHEN Status = 'Resolved' THEN 1 ELSE 0 END) AS Resolved,
-                SUM(CASE WHEN Status = 'Closed' THEN 1 ELSE 0 END) AS Closed,
-                SUM(CASE WHEN DueDate < CURRENT_TIMESTAMP AND Status NOT IN ('Resolved','Closed') THEN 1 ELSE 0 END) AS Overdue,
-                SUM(CASE WHEN DATE(DueDate) = DATE('now') AND Status NOT IN ('Resolved','Closed') THEN 1 ELSE 0 END) AS DueToday
-            FROM Issues
+                COUNT(*)                                                                                          AS Total,
+                SUM(CASE WHEN "Status" = 'Open'        THEN 1 ELSE 0 END)                                        AS Open,
+                SUM(CASE WHEN "Status" = 'InProgress'  THEN 1 ELSE 0 END)                                        AS InProgress,
+                SUM(CASE WHEN "Status" = 'Testing'     THEN 1 ELSE 0 END)                                        AS Testing,
+                SUM(CASE WHEN "Status" = 'Resolved'    THEN 1 ELSE 0 END)                                        AS Resolved,
+                SUM(CASE WHEN "Status" = 'Closed'      THEN 1 ELSE 0 END)                                        AS Closed,
+                SUM(CASE WHEN "DueDate" < NOW() AND "Status" NOT IN ('Resolved','Closed') THEN 1 ELSE 0 END)      AS Overdue,
+                SUM(CASE WHEN "DueDate"::date = CURRENT_DATE AND "Status" NOT IN ('Resolved','Closed') THEN 1 ELSE 0 END) AS DueToday
+            FROM "Issues"
             """;
         var row = await connection.QuerySingleAsync<dynamic>(sql);
         return new IssueSummaryDto(
-            (int)(row.Total ?? 0), (int)(row.Open ?? 0), (int)(row.InProgress ?? 0),
-            (int)(row.Testing ?? 0), (int)(row.Resolved ?? 0), (int)(row.Closed ?? 0),
-            (int)(row.Overdue ?? 0), (int)(row.DueToday ?? 0));
+            (int)(row.total ?? 0), (int)(row.open ?? 0), (int)(row.inprogress ?? 0),
+            (int)(row.testing ?? 0), (int)(row.resolved ?? 0), (int)(row.closed ?? 0),
+            (int)(row.overdue ?? 0), (int)(row.duetoday ?? 0));
     }
 
     public async Task<IReadOnlyList<IssueTrendDto>> GetIssueTrendsAsync(int days, CancellationToken ct = default)
     {
-        var sql = $"""
-            WITH dates AS (
-                SELECT DATE('now', '-' || (ROW_NUMBER() OVER() - 1) || ' days') AS d
-                FROM (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5
-                      UNION SELECT 6 UNION SELECT 7) t1,
-                     (SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5) t2
-                LIMIT {days}
-            )
+        const string sql = """
             SELECT
-                dates.d AS Date,
-                COUNT(CASE WHEN DATE(i.CreatedAt) = dates.d THEN 1 END) AS Created,
-                COUNT(CASE WHEN DATE(i.UpdatedAt) = dates.d AND i.Status = 'Resolved' THEN 1 END) AS Resolved,
-                COUNT(CASE WHEN DATE(i.UpdatedAt) = dates.d AND i.Status = 'Closed' THEN 1 END) AS Closed
-            FROM dates
-            LEFT JOIN Issues i ON DATE(i.CreatedAt) <= dates.d
-            GROUP BY dates.d
-            ORDER BY dates.d ASC
+                TO_CHAR("CreatedAt"::date, 'YYYY-MM-DD')                        AS "Date",
+                COUNT(*)::int                                                    AS "Created",
+                SUM(CASE WHEN "Status" = 'Resolved' THEN 1 ELSE 0 END)::int     AS "Resolved",
+                SUM(CASE WHEN "Status" = 'Closed'   THEN 1 ELSE 0 END)::int     AS "Closed"
+            FROM "Issues"
+            WHERE "CreatedAt" >= NOW() - (@Days::int * INTERVAL '1 day')
+            GROUP BY "CreatedAt"::date
+            ORDER BY "Date" ASC
             """;
-
-        // Simplified version that works reliably with SQLite
-        var fromDate = DateTime.UtcNow.AddDays(-days);
-        const string simpleSql = """
-            SELECT DATE(CreatedAt) AS Date,
-                   COUNT(*) AS Created,
-                   SUM(CASE WHEN Status = 'Resolved' THEN 1 ELSE 0 END) AS Resolved,
-                   SUM(CASE WHEN Status = 'Closed' THEN 1 ELSE 0 END) AS Closed
-            FROM Issues
-            WHERE CreatedAt >= @FromDate
-            GROUP BY DATE(CreatedAt)
-            ORDER BY Date ASC
-            """;
-        var rows = await connection.QueryAsync<IssueTrendDto>(simpleSql, new { FromDate = fromDate.ToString("o") });
+        var rows = await connection.QueryAsync<IssueTrendDto>(sql, new { Days = days });
         return rows.AsList();
     }
 
@@ -109,14 +89,14 @@ public class AnalyticsReadRepository(IDbConnection connection) : IAnalyticsReadR
     {
         const string sql = """
             SELECT
-                Priority,
-                AVG(CAST((JULIANDAY(UpdatedAt) - JULIANDAY(CreatedAt)) * 24 AS REAL)) AS AvgResolutionHours,
-                MIN(CAST((JULIANDAY(UpdatedAt) - JULIANDAY(CreatedAt)) * 24 AS REAL)) AS MinResolutionHours,
-                MAX(CAST((JULIANDAY(UpdatedAt) - JULIANDAY(CreatedAt)) * 24 AS REAL)) AS MaxResolutionHours,
-                COUNT(*) AS SampleSize
-            FROM Issues
-            WHERE Status IN ('Resolved', 'Closed') AND UpdatedAt IS NOT NULL
-            GROUP BY Priority
+                "Priority",
+                AVG(EXTRACT(EPOCH FROM ("UpdatedAt" - "CreatedAt")) / 3600.0)::float8  AS "AvgResolutionHours",
+                MIN(EXTRACT(EPOCH FROM ("UpdatedAt" - "CreatedAt")) / 3600.0)::float8  AS "MinResolutionHours",
+                MAX(EXTRACT(EPOCH FROM ("UpdatedAt" - "CreatedAt")) / 3600.0)::float8  AS "MaxResolutionHours",
+                COUNT(*)::int                                                            AS "SampleSize"
+            FROM "Issues"
+            WHERE "Status" IN ('Resolved', 'Closed') AND "UpdatedAt" IS NOT NULL
+            GROUP BY "Priority"
             """;
         var rows = await connection.QueryAsync<IssueResolutionTimeDto>(sql);
         return rows.AsList();
@@ -125,11 +105,13 @@ public class AnalyticsReadRepository(IDbConnection connection) : IAnalyticsReadR
     public async Task<IReadOnlyList<IssueStatsByStatusDto>> GetIssueStatsByStatusAsync(CancellationToken ct = default)
     {
         const string sql = """
-            SELECT Status, COUNT(*) AS Count,
-                   ROUND(COUNT(*) * 100.0 / SUM(COUNT(*)) OVER(), 2) AS Percentage
-            FROM Issues
-            GROUP BY Status
-            ORDER BY Count DESC
+            SELECT
+                "Status",
+                COUNT(*)::int                                               AS "Count",
+                ROUND(COUNT(*) * 100.0 / SUM(COUNT(*)) OVER(), 2)::float8  AS "Percentage"
+            FROM "Issues"
+            GROUP BY "Status"
+            ORDER BY "Count" DESC
             """;
         return (await connection.QueryAsync<IssueStatsByStatusDto>(sql)).AsList();
     }
@@ -137,11 +119,13 @@ public class AnalyticsReadRepository(IDbConnection connection) : IAnalyticsReadR
     public async Task<IReadOnlyList<IssueStatsByPriorityDto>> GetIssueStatsByPriorityAsync(CancellationToken ct = default)
     {
         const string sql = """
-            SELECT Priority, COUNT(*) AS Count,
-                   ROUND(COUNT(*) * 100.0 / SUM(COUNT(*)) OVER(), 2) AS Percentage
-            FROM Issues
-            GROUP BY Priority
-            ORDER BY Count DESC
+            SELECT
+                "Priority",
+                COUNT(*)::int                                               AS "Count",
+                ROUND(COUNT(*) * 100.0 / SUM(COUNT(*)) OVER(), 2)::float8  AS "Percentage"
+            FROM "Issues"
+            GROUP BY "Priority"
+            ORDER BY "Count" DESC
             """;
         return (await connection.QueryAsync<IssueStatsByPriorityDto>(sql)).AsList();
     }
@@ -149,16 +133,17 @@ public class AnalyticsReadRepository(IDbConnection connection) : IAnalyticsReadR
     public async Task<IReadOnlyList<IssueStatsByAssigneeDto>> GetIssueStatsByAssigneeAsync(CancellationToken ct = default)
     {
         const string sql = """
-            SELECT AssigneeId,
-                   SUM(CASE WHEN Status = 'Open' THEN 1 ELSE 0 END) AS Open,
-                   SUM(CASE WHEN Status = 'InProgress' THEN 1 ELSE 0 END) AS InProgress,
-                   SUM(CASE WHEN Status = 'Resolved' THEN 1 ELSE 0 END) AS Resolved,
-                   SUM(CASE WHEN Status = 'Closed' THEN 1 ELSE 0 END) AS Closed,
-                   COUNT(*) AS Total
-            FROM Issues
-            WHERE AssigneeId IS NOT NULL
-            GROUP BY AssigneeId
-            ORDER BY Total DESC
+            SELECT
+                "AssigneeId",
+                SUM(CASE WHEN "Status" = 'Open'       THEN 1 ELSE 0 END)::int AS "Open",
+                SUM(CASE WHEN "Status" = 'InProgress' THEN 1 ELSE 0 END)::int AS "InProgress",
+                SUM(CASE WHEN "Status" = 'Resolved'   THEN 1 ELSE 0 END)::int AS "Resolved",
+                SUM(CASE WHEN "Status" = 'Closed'     THEN 1 ELSE 0 END)::int AS "Closed",
+                COUNT(*)::int AS "Total"
+            FROM "Issues"
+            WHERE "AssigneeId" IS NOT NULL
+            GROUP BY "AssigneeId"
+            ORDER BY "Total" DESC
             """;
         return (await connection.QueryAsync<IssueStatsByAssigneeDto>(sql)).AsList();
     }
@@ -166,16 +151,16 @@ public class AnalyticsReadRepository(IDbConnection connection) : IAnalyticsReadR
     public async Task<IReadOnlyList<AssignSuggestionDto>> GetAssignSuggestionsAsync(CancellationToken ct = default)
     {
         const string sql = """
-            SELECT AssigneeId AS UserId,
-                   COUNT(CASE WHEN Status IN ('Open','InProgress') THEN 1 END) AS CurrentLoad,
-                   COUNT(CASE WHEN Status IN ('Resolved','Closed') THEN 1 END) AS Resolved,
-                   AVG(CASE WHEN Status IN ('Resolved','Closed') AND UpdatedAt IS NOT NULL
-                        THEN CAST((JULIANDAY(UpdatedAt) - JULIANDAY(CreatedAt)) * 24 AS REAL)
-                   END) AS AvgResolutionHours
-            FROM Issues
-            WHERE AssigneeId IS NOT NULL
-            GROUP BY AssigneeId
-            ORDER BY CurrentLoad ASC, AvgResolutionHours ASC
+            SELECT
+                "AssigneeId" AS "UserId",
+                COUNT(CASE WHEN "Status" IN ('Open','InProgress') THEN 1 END)::int        AS "CurrentLoad",
+                COUNT(CASE WHEN "Status" IN ('Resolved','Closed') THEN 1 END)::int        AS "Resolved",
+                AVG(CASE WHEN "Status" IN ('Resolved','Closed') AND "UpdatedAt" IS NOT NULL
+                    THEN EXTRACT(EPOCH FROM ("UpdatedAt" - "CreatedAt")) / 3600.0 END)::float8 AS "AvgResolutionHours"
+            FROM "Issues"
+            WHERE "AssigneeId" IS NOT NULL
+            GROUP BY "AssigneeId"
+            ORDER BY "CurrentLoad" ASC, "AvgResolutionHours" ASC
             LIMIT 5
             """;
         return (await connection.QueryAsync<AssignSuggestionDto>(sql)).AsList();
@@ -186,17 +171,18 @@ public class AnalyticsReadRepository(IDbConnection connection) : IAnalyticsReadR
     public async Task<IReadOnlyList<UserWorkloadSummaryDto>> GetAllUsersWorkloadAsync(CancellationToken ct = default)
     {
         const string sql = """
-            SELECT AssigneeId AS UserId,
-                   COUNT(*) AS TotalAssigned,
-                   SUM(CASE WHEN Status = 'Open' THEN 1 ELSE 0 END) AS Open,
-                   SUM(CASE WHEN Status = 'InProgress' THEN 1 ELSE 0 END) AS InProgress,
-                   SUM(CASE WHEN Status = 'Resolved' THEN 1 ELSE 0 END) AS Resolved,
-                   SUM(CASE WHEN Status = 'Closed' THEN 1 ELSE 0 END) AS Closed,
-                   SUM(CASE WHEN DueDate < CURRENT_TIMESTAMP AND Status NOT IN ('Resolved','Closed') THEN 1 ELSE 0 END) AS Overdue
-            FROM Issues
-            WHERE AssigneeId IS NOT NULL
-            GROUP BY AssigneeId
-            ORDER BY TotalAssigned DESC
+            SELECT
+                "AssigneeId" AS "UserId",
+                COUNT(*)::int AS "TotalAssigned",
+                SUM(CASE WHEN "Status" = 'Open'       THEN 1 ELSE 0 END)::int AS "Open",
+                SUM(CASE WHEN "Status" = 'InProgress' THEN 1 ELSE 0 END)::int AS "InProgress",
+                SUM(CASE WHEN "Status" = 'Resolved'   THEN 1 ELSE 0 END)::int AS "Resolved",
+                SUM(CASE WHEN "Status" = 'Closed'     THEN 1 ELSE 0 END)::int AS "Closed",
+                SUM(CASE WHEN "DueDate" < NOW() AND "Status" NOT IN ('Resolved','Closed') THEN 1 ELSE 0 END)::int AS "Overdue"
+            FROM "Issues"
+            WHERE "AssigneeId" IS NOT NULL
+            GROUP BY "AssigneeId"
+            ORDER BY "TotalAssigned" DESC
             """;
         return (await connection.QueryAsync<UserWorkloadSummaryDto>(sql)).AsList();
     }
@@ -204,19 +190,20 @@ public class AnalyticsReadRepository(IDbConnection connection) : IAnalyticsReadR
     public async Task<UserWorkloadDetailDto?> GetUserWorkloadAsync(Guid userId, CancellationToken ct = default)
     {
         const string sql = """
-            SELECT AssigneeId AS UserId,
-                   COUNT(*) AS TotalAssigned,
-                   SUM(CASE WHEN Status = 'Open' THEN 1 ELSE 0 END) AS Open,
-                   SUM(CASE WHEN Status = 'InProgress' THEN 1 ELSE 0 END) AS InProgress,
-                   SUM(CASE WHEN Status = 'Resolved' THEN 1 ELSE 0 END) AS Resolved,
-                   SUM(CASE WHEN Status = 'Closed' THEN 1 ELSE 0 END) AS Closed,
-                   SUM(CASE WHEN DueDate < CURRENT_TIMESTAMP AND Status NOT IN ('Resolved','Closed') THEN 1 ELSE 0 END) AS Overdue,
-                   AVG(CASE WHEN Status IN ('Resolved','Closed') AND UpdatedAt IS NOT NULL
-                        THEN CAST((JULIANDAY(UpdatedAt) - JULIANDAY(CreatedAt)) * 24 AS REAL) END) AS AvgResolutionHours,
-                   ROUND(COUNT(CASE WHEN Status IN ('Resolved','Closed') THEN 1 END) * 100.0 / COUNT(*), 2) AS CompletionRate
-            FROM Issues
-            WHERE UPPER(AssigneeId) = @UserId
-            GROUP BY AssigneeId
+            SELECT
+                "AssigneeId" AS "UserId",
+                COUNT(*)::int AS "TotalAssigned",
+                SUM(CASE WHEN "Status" = 'Open'       THEN 1 ELSE 0 END)::int AS "Open",
+                SUM(CASE WHEN "Status" = 'InProgress' THEN 1 ELSE 0 END)::int AS "InProgress",
+                SUM(CASE WHEN "Status" = 'Resolved'   THEN 1 ELSE 0 END)::int AS "Resolved",
+                SUM(CASE WHEN "Status" = 'Closed'     THEN 1 ELSE 0 END)::int AS "Closed",
+                SUM(CASE WHEN "DueDate" < NOW() AND "Status" NOT IN ('Resolved','Closed') THEN 1 ELSE 0 END)::int AS "Overdue",
+                AVG(CASE WHEN "Status" IN ('Resolved','Closed') AND "UpdatedAt" IS NOT NULL
+                    THEN EXTRACT(EPOCH FROM ("UpdatedAt" - "CreatedAt")) / 3600.0 END)::float8 AS "AvgResolutionHours",
+                ROUND(COUNT(CASE WHEN "Status" IN ('Resolved','Closed') THEN 1 END) * 100.0 / COUNT(*), 2)::float8 AS "CompletionRate"
+            FROM "Issues"
+            WHERE UPPER("AssigneeId"::text) = @UserId
+            GROUP BY "AssigneeId"
             """;
         return await connection.QuerySingleOrDefaultAsync<UserWorkloadDetailDto>(sql, new { UserId = GH.Up(userId) });
     }
@@ -224,15 +211,16 @@ public class AnalyticsReadRepository(IDbConnection connection) : IAnalyticsReadR
     public async Task<UserStatisticsDto?> GetUserStatisticsAsync(Guid userId, CancellationToken ct = default)
     {
         const string sql = """
-            SELECT AssigneeId AS UserId,
-                   COUNT(CASE WHEN Status IN ('Resolved','Closed') THEN 1 END) AS TotalResolved,
-                   AVG(CASE WHEN Status IN ('Resolved','Closed') AND UpdatedAt IS NOT NULL
-                        THEN CAST((JULIANDAY(UpdatedAt) - JULIANDAY(CreatedAt)) * 24 AS REAL) END) AS AvgResolutionHours,
-                   ROUND(COUNT(CASE WHEN Status IN ('Resolved','Closed') THEN 1 END) * 100.0 / COUNT(*), 2) AS CompletionRate,
-                   COUNT(CASE WHEN Status IN ('Open','InProgress') THEN 1 END) AS CurrentLoad
-            FROM Issues
-            WHERE UPPER(AssigneeId) = @UserId
-            GROUP BY AssigneeId
+            SELECT
+                "AssigneeId" AS "UserId",
+                COUNT(CASE WHEN "Status" IN ('Resolved','Closed') THEN 1 END)::int AS "TotalResolved",
+                AVG(CASE WHEN "Status" IN ('Resolved','Closed') AND "UpdatedAt" IS NOT NULL
+                    THEN EXTRACT(EPOCH FROM ("UpdatedAt" - "CreatedAt")) / 3600.0 END)::float8 AS "AvgResolutionHours",
+                ROUND(COUNT(CASE WHEN "Status" IN ('Resolved','Closed') THEN 1 END) * 100.0 / COUNT(*), 2)::float8 AS "CompletionRate",
+                COUNT(CASE WHEN "Status" IN ('Open','InProgress') THEN 1 END)::int AS "CurrentLoad"
+            FROM "Issues"
+            WHERE UPPER("AssigneeId"::text) = @UserId
+            GROUP BY "AssigneeId"
             """;
         return await connection.QuerySingleOrDefaultAsync<UserStatisticsDto>(sql, new { UserId = GH.Up(userId) });
     }
@@ -243,35 +231,39 @@ public class AnalyticsReadRepository(IDbConnection connection) : IAnalyticsReadR
     {
         const string totalSql = """
             SELECT
-                SUM(CurrentStock * UnitPrice) AS TotalValue,
-                SUM(CurrentStock * CostPrice) AS TotalCostValue
-            FROM Products WHERE IsActive = 1
+                SUM("CurrentStock" * "UnitPrice") AS TotalValue,
+                SUM("CurrentStock" * "CostPrice") AS TotalCostValue
+            FROM "Products" WHERE "IsActive" = true
             """;
         var total = await connection.QuerySingleAsync<dynamic>(totalSql);
 
         const string byCatSql = """
-            SELECT Category, COUNT(*) AS ProductCount,
-                   SUM(CurrentStock * UnitPrice) AS TotalValue,
-                   SUM(CurrentStock * CostPrice) AS TotalCostValue
-            FROM Products WHERE IsActive = 1
-            GROUP BY Category ORDER BY TotalValue DESC
+            SELECT
+                "Category",
+                COUNT(*) AS ProductCount,
+                SUM("CurrentStock" * "UnitPrice") AS TotalValue,
+                SUM("CurrentStock" * "CostPrice") AS TotalCostValue
+            FROM "Products" WHERE "IsActive" = true
+            GROUP BY "Category" ORDER BY TotalValue DESC
             """;
         var byCategory = (await connection.QueryAsync<CategoryValueDto>(byCatSql)).AsList();
 
         const string byLocSql = """
-            SELECT p.LocationId, COALESCE(l.Name, 'No Location') AS LocationName,
-                   COUNT(*) AS ProductCount,
-                   SUM(p.CurrentStock * p.UnitPrice) AS TotalValue
-            FROM Products p
-            LEFT JOIN Locations l ON UPPER(l.Id) = UPPER(p.LocationId)
-            WHERE p.IsActive = 1
-            GROUP BY p.LocationId ORDER BY TotalValue DESC
+            SELECT
+                p."LocationId",
+                COALESCE(l."Name", 'No Location') AS LocationName,
+                COUNT(*) AS ProductCount,
+                SUM(p."CurrentStock" * p."UnitPrice") AS TotalValue
+            FROM "Products" p
+            LEFT JOIN "Locations" l ON l."Id"::text = p."LocationId"::text
+            WHERE p."IsActive" = true
+            GROUP BY p."LocationId", l."Name" ORDER BY TotalValue DESC
             """;
         var byLocation = (await connection.QueryAsync<LocationValueDto>(byLocSql)).AsList();
 
         return new InventoryValueDto(
-            (decimal)(total.TotalValue ?? 0),
-            (decimal)(total.TotalCostValue ?? 0),
+            (decimal)(total.totalvalue ?? 0),
+            (decimal)(total.totalcostvalue ?? 0),
             byCategory,
             byLocation);
     }
@@ -280,61 +272,65 @@ public class AnalyticsReadRepository(IDbConnection connection) : IAnalyticsReadR
     {
         const string sql = """
             SELECT
-                COUNT(*) AS TotalProducts,
-                SUM(CASE WHEN IsActive = 1 AND StockStatus != 'Discontinued' THEN 1 ELSE 0 END) AS ActiveProducts,
-                SUM(CASE WHEN StockStatus = 'Discontinued' THEN 1 ELSE 0 END) AS DiscontinuedProducts,
-                SUM(CASE WHEN StockStatus = 'LowStock' THEN 1 ELSE 0 END) AS LowStockProducts,
-                SUM(CASE WHEN StockStatus = 'OutOfStock' THEN 1 ELSE 0 END) AS OutOfStockProducts,
-                SUM(CASE WHEN StockStatus = 'Overstock' THEN 1 ELSE 0 END) AS OverstockProducts,
-                SUM(CurrentStock * UnitPrice) AS TotalInventoryValue
-            FROM Products
+                COUNT(*)                                                                       AS TotalProducts,
+                SUM(CASE WHEN "IsActive" = true AND "StockStatus" != 'Discontinued' THEN 1 ELSE 0 END) AS ActiveProducts,
+                SUM(CASE WHEN "StockStatus" = 'Discontinued' THEN 1 ELSE 0 END)               AS DiscontinuedProducts,
+                SUM(CASE WHEN "StockStatus" = 'LowStock'     THEN 1 ELSE 0 END)               AS LowStockProducts,
+                SUM(CASE WHEN "StockStatus" = 'OutOfStock'   THEN 1 ELSE 0 END)               AS OutOfStockProducts,
+                SUM(CASE WHEN "StockStatus" = 'Overstock'    THEN 1 ELSE 0 END)               AS OverstockProducts,
+                SUM("CurrentStock" * "UnitPrice")                                              AS TotalInventoryValue
+            FROM "Products"
             """;
         var row = await connection.QuerySingleAsync<dynamic>(sql);
         return new InventorySummaryDto(
-            (int)(row.TotalProducts ?? 0),
-            (int)(row.ActiveProducts ?? 0),
-            (int)(row.DiscontinuedProducts ?? 0),
-            (int)(row.LowStockProducts ?? 0),
-            (int)(row.OutOfStockProducts ?? 0),
-            (int)(row.OverstockProducts ?? 0),
-            (decimal)(row.TotalInventoryValue ?? 0));
+            (int)(row.totalproducts ?? 0),
+            (int)(row.activeproducts ?? 0),
+            (int)(row.discontinuedproducts ?? 0),
+            (int)(row.lowstockproducts ?? 0),
+            (int)(row.outofstockproducts ?? 0),
+            (int)(row.overstockproducts ?? 0),
+            (decimal)(row.totalinventoryvalue ?? 0));
     }
 
     public async Task<IReadOnlyList<StockStatusDistributionDto>> GetStockStatusDistributionAsync(CancellationToken ct = default)
     {
         const string sql = """
-            SELECT StockStatus AS Status, COUNT(*) AS Count,
-                   ROUND(COUNT(*) * 100.0 / SUM(COUNT(*)) OVER(), 2) AS Percentage
-            FROM Products
-            GROUP BY StockStatus ORDER BY Count DESC
+            SELECT
+                "StockStatus" AS "Status",
+                COUNT(*)::int AS "Count",
+                ROUND(COUNT(*) * 100.0 / SUM(COUNT(*)) OVER(), 2)::float8 AS "Percentage"
+            FROM "Products"
+            GROUP BY "StockStatus" ORDER BY "Count" DESC
             """;
         return (await connection.QueryAsync<StockStatusDistributionDto>(sql)).AsList();
     }
 
     public async Task<IReadOnlyList<StockTrendDto>> GetStockTrendsAsync(int days, CancellationToken ct = default)
     {
-        var fromDate = DateTime.UtcNow.AddDays(-days);
         const string sql = """
-            SELECT DATE(MovementDate) AS Date,
-                   SUM(CASE WHEN MovementType IN ('StockIn','Purchase','InitialStock','Return') THEN Quantity ELSE 0 END) AS TotalIn,
-                   SUM(CASE WHEN MovementType IN ('StockOut','Sale','Damage','Loss','Expired') THEN Quantity ELSE 0 END) AS TotalOut,
-                   SUM(CASE WHEN MovementType IN ('StockIn','Purchase','InitialStock','Return') THEN Quantity ELSE 0 END) -
-                   SUM(CASE WHEN MovementType IN ('StockOut','Sale','Damage','Loss','Expired') THEN Quantity ELSE 0 END) AS NetChange
-            FROM StockMovements
-            WHERE MovementDate >= @FromDate
-            GROUP BY DATE(MovementDate)
+            SELECT
+                TO_CHAR("MovementDate"::date, 'YYYY-MM-DD') AS Date,
+                SUM(CASE WHEN "MovementType" IN ('StockIn','Purchase','InitialStock','Return') THEN "Quantity" ELSE 0 END) AS TotalIn,
+                SUM(CASE WHEN "MovementType" IN ('StockOut','Sale','Damage','Loss','Expired')  THEN "Quantity" ELSE 0 END) AS TotalOut,
+                SUM(CASE WHEN "MovementType" IN ('StockIn','Purchase','InitialStock','Return') THEN "Quantity" ELSE 0 END) -
+                SUM(CASE WHEN "MovementType" IN ('StockOut','Sale','Damage','Loss','Expired')  THEN "Quantity" ELSE 0 END) AS NetChange
+            FROM "StockMovements"
+            WHERE "MovementDate" >= NOW() - (@Days::int * INTERVAL '1 day')
+            GROUP BY "MovementDate"::date
             ORDER BY Date ASC
             """;
-        return (await connection.QueryAsync<StockTrendDto>(sql, new { FromDate = fromDate.ToString("o") })).AsList();
+        return (await connection.QueryAsync<StockTrendDto>(sql, new { Days = days })).AsList();
     }
 
     public async Task<IReadOnlyList<CategoryDistributionDto>> GetCategoryDistributionAsync(CancellationToken ct = default)
     {
         const string sql = """
-            SELECT Category, COUNT(*) AS Count,
-                   ROUND(COUNT(*) * 100.0 / SUM(COUNT(*)) OVER(), 2) AS Percentage
-            FROM Products
-            GROUP BY Category ORDER BY Count DESC
+            SELECT
+                "Category",
+                COUNT(*)::int AS "Count",
+                ROUND(COUNT(*) * 100.0 / SUM(COUNT(*)) OVER(), 2)::float8 AS "Percentage"
+            FROM "Products"
+            GROUP BY "Category" ORDER BY "Count" DESC
             """;
         return (await connection.QueryAsync<CategoryDistributionDto>(sql)).AsList();
     }
@@ -342,14 +338,16 @@ public class AnalyticsReadRepository(IDbConnection connection) : IAnalyticsReadR
     public async Task<IReadOnlyList<TurnoverRateDto>> GetTurnoverRateAsync(int topN, CancellationToken ct = default)
     {
         var sql = $"""
-            SELECT p.Id AS ProductId, p.Name AS ProductName, p.SKU,
-                   COUNT(sm.Id) AS TotalMovements,
-                   SUM(CASE WHEN sm.MovementType IN ('StockOut','Sale','Damage','Loss','Expired') THEN sm.Quantity ELSE 0 END) AS TotalOut,
-                   ROUND(CAST(SUM(CASE WHEN sm.MovementType IN ('StockOut','Sale','Damage','Loss','Expired') THEN sm.Quantity ELSE 0 END) AS REAL)
-                         / NULLIF(AVG(p.CurrentStock), 0), 4) AS TurnoverRate
-            FROM Products p
-            LEFT JOIN StockMovements sm ON UPPER(sm.ProductId) = UPPER(p.Id)
-            GROUP BY p.Id, p.Name, p.SKU
+            SELECT
+                p."Id" AS ProductId, p."Name" AS ProductName, p."SKU",
+                COUNT(sm."Id") AS TotalMovements,
+                SUM(CASE WHEN sm."MovementType" IN ('StockOut','Sale','Damage','Loss','Expired') THEN sm."Quantity" ELSE 0 END) AS TotalOut,
+                ROUND(
+                    CAST(SUM(CASE WHEN sm."MovementType" IN ('StockOut','Sale','Damage','Loss','Expired') THEN sm."Quantity" ELSE 0 END) AS numeric)
+                    / NULLIF(AVG(p."CurrentStock"), 0), 4) AS TurnoverRate
+            FROM "Products" p
+            LEFT JOIN "StockMovements" sm ON sm."ProductId" = p."Id"
+            GROUP BY p."Id", p."Name", p."SKU"
             ORDER BY TurnoverRate DESC
             LIMIT {topN}
             """;
@@ -358,31 +356,34 @@ public class AnalyticsReadRepository(IDbConnection connection) : IAnalyticsReadR
 
     public async Task<IReadOnlyList<ExpiringProductDto>> GetExpiringProductsAsync(int daysAhead, int page, int pageSize, CancellationToken ct = default)
     {
-        var until = DateTime.UtcNow.AddDays(daysAhead);
         var sql = $"""
-            SELECT Id AS ProductId, Name AS ProductName, SKU,
-                   CurrentStock, ExpiryDate,
-                   CAST(JULIANDAY(ExpiryDate) - JULIANDAY('now') AS INTEGER) AS DaysUntilExpiry
-            FROM Products
-            WHERE ExpiryDate IS NOT NULL AND ExpiryDate <= @Until AND ExpiryDate >= DATE('now')
-              AND IsActive = 1
-            ORDER BY ExpiryDate ASC
+            SELECT
+                "Id" AS ProductId, "Name" AS ProductName, "SKU",
+                "CurrentStock", "ExpiryDate",
+                EXTRACT(DAY FROM ("ExpiryDate" - NOW()))::int AS DaysUntilExpiry
+            FROM "Products"
+            WHERE "ExpiryDate" IS NOT NULL
+              AND "ExpiryDate" <= NOW() + (@DaysAhead::int * INTERVAL '1 day')
+              AND "ExpiryDate" >= CURRENT_DATE
+              AND "IsActive" = true
+            ORDER BY "ExpiryDate" ASC
             LIMIT {pageSize} OFFSET {(page - 1) * pageSize}
             """;
-        return (await connection.QueryAsync<ExpiringProductDto>(sql, new { Until = until.ToString("o") })).AsList();
+        return (await connection.QueryAsync<ExpiringProductDto>(sql, new { DaysAhead = daysAhead })).AsList();
     }
 
     public async Task<IReadOnlyList<LocationCapacityDto>> GetLocationCapacityAsync(CancellationToken ct = default)
     {
         const string sql = """
-            SELECT l.Id AS LocationId, l.Name AS LocationName, l.Code AS LocationCode,
-                   l.Capacity,
-                   COALESCE(SUM(p.CurrentStock), 0) AS CurrentStock,
-                   ROUND(COALESCE(SUM(p.CurrentStock), 0) * 100.0 / NULLIF(l.Capacity, 0), 2) AS UtilizationPercent
-            FROM Locations l
-            LEFT JOIN Products p ON UPPER(p.LocationId) = UPPER(l.Id) AND p.IsActive = 1
-            WHERE l.IsActive = 1
-            GROUP BY l.Id, l.Name, l.Code, l.Capacity
+            SELECT
+                l."Id" AS LocationId, l."Name" AS LocationName, l."Code" AS LocationCode,
+                l."Capacity",
+                COALESCE(SUM(p."CurrentStock"), 0) AS CurrentStock,
+                ROUND(COALESCE(SUM(p."CurrentStock"), 0) * 100.0 / NULLIF(l."Capacity", 0), 2) AS UtilizationPercent
+            FROM "Locations" l
+            LEFT JOIN "Products" p ON p."LocationId" = l."Id" AND p."IsActive" = true
+            WHERE l."IsActive" = true
+            GROUP BY l."Id", l."Name", l."Code", l."Capacity"
             ORDER BY UtilizationPercent DESC
             """;
         return (await connection.QueryAsync<LocationCapacityDto>(sql)).AsList();
@@ -391,16 +392,17 @@ public class AnalyticsReadRepository(IDbConnection connection) : IAnalyticsReadR
     public async Task<IReadOnlyList<SupplierPerformanceDto>> GetSupplierPerformanceAsync(CancellationToken ct = default)
     {
         const string sql = """
-            SELECT s.Id AS SupplierId, s.Name AS SupplierName, s.Code AS SupplierCode,
-                   COUNT(DISTINCT p.Id) AS TotalProducts,
-                   COUNT(sm.Id) AS TotalPurchases,
-                   SUM(CASE WHEN sm.MovementType = 'Purchase' THEN sm.Quantity * p.CostPrice ELSE 0 END) AS TotalPurchaseValue
-            FROM Suppliers s
-            LEFT JOIN Products p ON UPPER(p.SupplierId) = UPPER(s.Id)
-            LEFT JOIN StockMovements sm ON UPPER(sm.ProductId) = UPPER(p.Id)
-                AND sm.MovementType IN ('StockIn','Purchase')
-            WHERE s.IsActive = 1
-            GROUP BY s.Id, s.Name, s.Code
+            SELECT
+                s."Id" AS SupplierId, s."Name" AS SupplierName, s."Code" AS SupplierCode,
+                COUNT(DISTINCT p."Id") AS TotalProducts,
+                COUNT(sm."Id") AS TotalPurchases,
+                SUM(CASE WHEN sm."MovementType" = 'Purchase' THEN sm."Quantity" * p."CostPrice" ELSE 0 END) AS TotalPurchaseValue
+            FROM "Suppliers" s
+            LEFT JOIN "Products" p ON p."SupplierId" = s."Id"
+            LEFT JOIN "StockMovements" sm ON sm."ProductId" = p."Id"
+                AND sm."MovementType" IN ('StockIn','Purchase')
+            WHERE s."IsActive" = true
+            GROUP BY s."Id", s."Name", s."Code"
             ORDER BY TotalPurchaseValue DESC
             """;
         return (await connection.QueryAsync<SupplierPerformanceDto>(sql)).AsList();
@@ -416,14 +418,15 @@ public class AnalyticsReadRepository(IDbConnection connection) : IAnalyticsReadR
         };
 
         var sql = $"""
-            SELECT p.Id AS ProductId, p.Name AS ProductName, p.SKU, p.Category,
-                   p.CurrentStock, p.UnitPrice,
-                   p.CurrentStock * p.UnitPrice AS TotalValue,
-                   COUNT(sm.Id) AS TotalMovements
-            FROM Products p
-            LEFT JOIN StockMovements sm ON UPPER(sm.ProductId) = UPPER(p.Id)
-            WHERE p.IsActive = 1
-            GROUP BY p.Id, p.Name, p.SKU, p.Category, p.CurrentStock, p.UnitPrice
+            SELECT
+                p."Id" AS ProductId, p."Name" AS ProductName, p."SKU", p."Category",
+                p."CurrentStock", p."UnitPrice",
+                p."CurrentStock" * p."UnitPrice" AS TotalValue,
+                COUNT(sm."Id") AS TotalMovements
+            FROM "Products" p
+            LEFT JOIN "StockMovements" sm ON sm."ProductId" = p."Id"
+            WHERE p."IsActive" = true
+            GROUP BY p."Id", p."Name", p."SKU", p."Category", p."CurrentStock", p."UnitPrice"
             ORDER BY {orderClause}
             LIMIT {topN}
             """;

--- a/docs/TECHNICAL_GUIDE.md
+++ b/docs/TECHNICAL_GUIDE.md
@@ -349,10 +349,58 @@ O token JWT **nunca** é exposto ao JavaScript do browser.
 ## Frontend — Blazor WASM
 
 - Framework: **.NET 9 Blazor WASM** com **MudBlazor**
-- Compilado como **Custom Elements** para integração no Next.js via `<BlazorHost>`
+- Compilado como **Custom Elements** para integração no Next.js via componente `<BlazorHost>`
+- Os artefatos compilados (`.wasm`, `.dll`, `blazor.webassembly.js`) são copiados para `public/_blazor/` durante o build do Next.js
 - Componentes principais:
-  - `InventoryGrid` — MudDataGrid com CRUD
-  - `AnalyticsDashboard` — Charts e KPIs em tempo real
+  - `InventoryGrid` — MudDataGrid com CRUD completo de produtos
+  - `AnalyticsDashboard` — Charts (linha, donut, barra) e KPI cards com dados em tempo real
+
+### Integração Next.js ↔ Blazor WASM
+
+O Blazor é servido como micro-frontend embarcado no Next.js. O fluxo é:
+
+```
+Next.js page → <BlazorHost> component
+  → carrega /public/_blazor/blazor.webassembly.js
+  → carrega /public/_blazor/_framework/* (dotnet.wasm, dotnet.js, …)
+  → renderiza <inventory-grid> ou <analytics-dashboard> (Custom Elements)
+```
+
+**Rewrites no `next.config.ts`** garantem que as requisições dos Custom Elements
+aos caminhos `/_framework/*` e `/_content/*` sejam resolvidas para os arquivos
+estáticos corretos em `public/_blazor/`:
+
+```ts
+// next.config.ts — beforeFiles rewrites
+{ source: '/_framework/:path*', destination: '/public/_blazor/_framework/:path*' },
+{ source: '/_content/:path*',   destination: '/public/_blazor/_content/:path*'  },
+// also handles page-prefixed paths (e.g. /analytics/_framework/...)
+```
+
+**Build automático do Blazor** — o script `predev` no `package.json` do Next.js
+garante que o Blazor seja sempre recompilado antes de `next dev` / `next build`
+em ambiente local:
+
+```json
+"predev":  "bash ../../scripts/build-blazor.sh",
+"prebuild": "bash ../../scripts/build-blazor.sh"
+```
+
+> No Docker, o build do Blazor é feito diretamente no `Dockerfile.frontend`
+> antes do `next build`, sem usar o script `prebuild` do npm para evitar
+> conflitos na imagem.
+
+### Comunicação Blazor → Backend (via BFF)
+
+O `HttpClient` configurado no Blazor aponta para `/api/proxy/` (mesmo origem).
+O Next.js BFF (`app/api/proxy/[...path]/route.ts`) injeta o token JWT do cookie
+HttpOnly antes de repassar a requisição ao backend .NET:
+
+```
+Blazor WASM → GET /api/proxy/analytics/dashboard
+  → Next.js BFF (injeta Bearer token do cookie ims_access_token)
+  → GET http://app:8080/api/analytics/dashboard  (200 OK)
+```
 
 ---
 
@@ -363,6 +411,17 @@ O token JWT **nunca** é exposto ao JavaScript do browser.
 - ORM: **EF Core 9** com migrations por módulo
 - Cada módulo tem seu próprio `DbContext`
 - Migrations são aplicadas automaticamente no startup (Development) ou via CI (Production)
+- **Dapper** é usado nas queries de leitura (Analytics, Inventory read models) — todas as queries usam sintaxe PostgreSQL com identificadores entre aspas duplas (`"TableName"`) pois o PostgreSQL é case-sensitive
+
+### Convenções de queries Dapper (PostgreSQL)
+
+| Regra | Exemplo |
+|---|---|
+| Nomes de tabelas/colunas entre aspas duplas | `SELECT "Status" FROM "Issues"` |
+| Cast explícito para tipos C# | `COUNT(*)::int`, `AVG(...)::float8` |
+| Alias PascalCase para mapear para records C# | `COUNT(*) AS "Count"` |
+| Booleanos: usar `true`/`false` literal | `WHERE "IsActive" = true` |
+| Datas: usar `CURRENT_DATE`, `INTERVAL '30 days'` | `WHERE "CreatedAt" >= CURRENT_DATE - INTERVAL '30 days'` |
 
 ### Rodando migrations manualmente
 
@@ -603,6 +662,41 @@ O `dotnet publish` precisa apontar explicitamente para o `.csproj`:
 RUN dotnet publish -c Release --no-restore -o /publish \
     /p:UseAppHost=false backend/src/*.csproj
 ```
+
+### Analytics dashboard retorna 422 no Blazor
+
+O erro `422 Unprocessable Entity` nas chamadas `/api/proxy/analytics/*` indica
+que o token JWT não está sendo enviado. Verifique:
+
+1. Se o cookie `ims_access_token` existe no browser (DevTools → Application → Cookies)
+2. Se o Next.js BFF está rodando (container `ims-frontend` healthy)
+3. Se o `HttpClient` do Blazor aponta para a URL correta (deve usar `/api/proxy/`, não a URL direta do backend)
+
+### Recursos Blazor retornam 404 (`_framework/dotnet.js`, `_content/*`)
+
+Os arquivos estáticos do Blazor WASM precisam estar em `public/_blazor/` no Next.js. Se estiverem faltando:
+
+```bash
+# Recompilar o Blazor e copiar para public/
+bash scripts/build-blazor.sh
+
+# Ou em dev local:
+cd frontend/apps/next-shell
+npm run dev   # executa predev que chama build-blazor.sh automaticamente
+```
+
+Para rebuild completo do Docker:
+```bash
+docker compose build --no-cache frontend
+docker compose up -d
+```
+
+### "Blazor has already started" no console
+
+Aviso benigno que ocorre em navegação SPA — o Blazor runtime não pode ser
+iniciado duas vezes na mesma página. O componente `<BlazorHost>` já possui
+guards para evitar o segundo `Blazor.start()`. O aviso pode ser ignorado com
+segurança.
 
 ---
 

--- a/frontend/apps/next-shell/components/blazor-host.tsx
+++ b/frontend/apps/next-shell/components/blazor-host.tsx
@@ -39,18 +39,16 @@ export function BlazorHost({ mountDelay = 100 }: BlazorHostProps) {
       return;
     }
 
-    // Probe before loading any Blazor script — avoids the uncaught promise
-    // error from blazor.webassembly.js that freezes input event handlers.
-    fetch('/_blazor/_framework/blazor.webassembly.js', { method: 'HEAD' })
+    // Probe using the rewrite path (/_framework/*) — if rewrite is working the
+    // file will be served from public/_blazor/_framework/.
+    fetch('/_framework/blazor.webassembly.js', { method: 'HEAD' })
       .then((r) => setBlazorAvailable(r.ok))
       .catch(() => setBlazorAvailable(false));
   }, []);
 
-  // Don't render Blazor scripts at all when the framework files are absent.
   if (blazorAvailable === false) return null;
-  if (blazorAvailable === null) return null; // still probing
+  if (blazorAvailable === null) return null;
 
-  // If already started, no need to inject scripts again.
   if ((window as any).__blazorStarted) return null;
 
   return (
@@ -59,33 +57,31 @@ export function BlazorHost({ mountDelay = 100 }: BlazorHostProps) {
         rel="stylesheet"
         href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
       />
-      <link rel="stylesheet" href="/_blazor/_content/MudBlazor/MudBlazor.min.css" />
+      {/* Use /_content/ rewrite path so MudBlazor CSS sub-resources resolve correctly */}
+      <link rel="stylesheet" href="/_content/MudBlazor/MudBlazor.min.css" />
 
+      {/*
+        Load via /_framework/ (rewritten by next.config to /_blazor/_framework/).
+        This ensures import.meta.url = /_framework/blazor.webassembly.js so all
+        internal dynamic imports (dotnet.js, dotnet.native.*.js, etc.) resolve to
+        /_framework/* — which next.config already rewrites to /_blazor/_framework/*.
+        The tempBase trick does NOT work for ES module import() resolution.
+      */}
       <Script
-        src="/_blazor/_framework/blazor.webassembly.js"
+        src="/_framework/blazor.webassembly.js"
         strategy="lazyOnload"
         data-no-auto-start="true"
         onLoad={() => {
           setTimeout(async () => {
             if ((window as any).__blazorStarted) return;
             (window as any).__blazorStarted = true;
-            window.Blazor?.start({
-              loadBootResource: (
-                _type: string,
-                filename: string,
-                defaultUri: string,
-                _integrity: string
-              ) => {
-                // Rewrite relative _framework/* URLs to use the correct /_blazor/ prefix
-                if (defaultUri.includes('_framework/')) {
-                  return `/_blazor/_framework/${filename}`;
-                }
-                return defaultUri;
-              },
-            }).catch((err: unknown) => {
+
+            try {
+              await window.Blazor?.start({});
+            } catch (err: unknown) {
               console.warn('[BlazorHost] Blazor start failed:', err);
               (window as any).__blazorStarted = false;
-            });
+            }
           }, mountDelay);
         }}
         onError={() => {
@@ -94,7 +90,7 @@ export function BlazorHost({ mountDelay = 100 }: BlazorHostProps) {
       />
 
       <Script
-        src="/_blazor/_content/MudBlazor/MudBlazor.min.js"
+        src="/_content/MudBlazor/MudBlazor.min.js"
         strategy="lazyOnload"
       />
     </>

--- a/frontend/apps/next-shell/next.config.ts
+++ b/frontend/apps/next-shell/next.config.ts
@@ -9,28 +9,45 @@ const nextConfig: NextConfig = {
   // Habilita output standalone para Docker (copia apenas os arquivos necessários)
   output: "standalone",
   async rewrites() {
-    return [
-      // /api/proxy/** is handled by app/api/proxy/[...path]/route.ts (authenticated BFF)
-      // Proxy SignalR hubs to backend
-      {
-        source: "/hubs/:path*",
-        destination: `${IMS_API_URL}/hubs/:path*`,
-      },
-      // NOTE: Blazor WASM static files are served directly from public/_blazor/
-      // Do NOT proxy /_blazor/ to backend — Next.js serves them as static files.
-
-      // Blazor's dotnet.js makes dynamic imports relative to the page baseURI,
-      // producing /_framework/* and /_content/* (without the /_blazor/ prefix).
-      // These rewrites transparently redirect those requests to the correct paths.
-      {
-        source: "/_framework/:path*",
-        destination: "/_blazor/_framework/:path*",
-      },
-      {
-        source: "/_content/:path*",
-        destination: "/_blazor/_content/:path*",
-      },
-    ];
+    return {
+      // beforeFiles: run BEFORE static files are checked.
+      // Required so that /_framework/* and /_content/* resolve to the Blazor
+      // artifacts in public/_blazor/ before Next.js returns 404 for those paths.
+      // Blazor WASM uses document.baseURI (not import.meta.url) to construct
+      // resource URLs, so all internal fetches come in as /_framework/* and
+      // /_content/* — these rewrites map them back to the correct public path.
+      beforeFiles: [
+        // Absolute paths (Blazor loaded from /_framework/)
+        {
+          source: "/_framework/:path*",
+          destination: "/_blazor/_framework/:path*",
+        },
+        {
+          source: "/_content/:path*",
+          destination: "/_blazor/_content/:path*",
+        },
+        // Relative paths: Blazor resolves _content/* and _framework/* using
+        // document.baseURI (the current page URL). When the user is on /analytics,
+        // /issues, etc., those requests arrive as /:page*/_content/* — catch them all.
+        {
+          source: "/:prefix*/_framework/:path*",
+          destination: "/_blazor/_framework/:path*",
+        },
+        {
+          source: "/:prefix*/_content/:path*",
+          destination: "/_blazor/_content/:path*",
+        },
+      ],
+      afterFiles: [
+        // /api/proxy/** is handled by app/api/proxy/[...path]/route.ts (authenticated BFF)
+        // Proxy SignalR hubs to backend
+        {
+          source: "/hubs/:path*",
+          destination: `${IMS_API_URL}/hubs/:path*`,
+        },
+      ],
+      fallback: [],
+    };
   },
   async headers() {
     return [

--- a/frontend/apps/next-shell/package.json
+++ b/frontend/apps/next-shell/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
+    "blazor:build": "bash ../../../scripts/build-blazor.sh",
+    "predev": "npm run blazor:build",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",


### PR DESCRIPTION
## Resumo

Corrige os erros que impediam o carregamento do dashboard de analytics no Blazor WASM embarcado no Next.js.

## Problemas resolvidos

### Backend — SQL queries incompatíveis com PostgreSQL
- `AnalyticsReadRepository.cs`: todas as queries Dapper reescritas para PostgreSQL
  - Identificadores entre aspas duplas (`"TableName"`, `"ColumnName"`)
  - Casts explícitos: `COUNT(*)::int`, `AVG(...)::float8`
  - Aliases PascalCase para mapear corretamente aos record constructors C# (`COUNT(*) AS "Count"`)
  - Datas: `CURRENT_DATE - INTERVAL '30 days'` em vez de `date('now', '-30 days')`
  - Booleanos: `true`/`false` literal em vez de `1`/`0`

### Frontend — Recursos estáticos do Blazor (404 → 200)
- `next.config.ts`: rewrites `beforeFiles` para servir `/_framework/*` e `/_content/*`
  a partir de `/public/_blazor/`, incluindo caminhos prefixados por página

### Frontend — Guard contra duplo Blazor.start()
- `blazor-host.tsx`: guard para evitar `Blazor has already started` em navegação SPA

### Frontend — Build automático do Blazor em dev local
- `package.json`: scripts `predev`/`prebuild` chamam `build-blazor.sh` automaticamente

## Documentação

- **README.md**: tech stack dividido em Backend/Frontend; Getting Started simplificado com fluxo Docker
- **docs/TECHNICAL_GUIDE.md**: seção detalhada de integração Next.js ↔ Blazor WASM, convenções de queries Dapper/PostgreSQL, novos itens de Troubleshooting

## Testes

- Endpoints `/api/analytics/dashboard`, `/api/analytics/issues/by-status`, `/api/analytics/issues/by-priority` validados retornando HTTP 200 via logs Docker
- Cache Redis (HIT) confirmado após primeira execução bem-sucedida das queries PostgreSQL