### PR TITLE
US-062: Issues — Kanban Board view com drag-and-drop

### DIFF
--- a/frontend/apps/next-shell/__tests__/issues/kanban.test.tsx
+++ b/frontend/apps/next-shell/__tests__/issues/kanban.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * US-062: Testes unitários para componentes Kanban
+ */
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import React from "react";
+import type { IssueDto } from "@/lib/types";
+
+// ── Mocks dnd-kit ─────────────────────────────────────────────────────────
+
+vi.mock("@dnd-kit/core", () => ({
+  DndContext: ({ children }: { children: React.ReactNode }) => <div data-testid="dnd-context">{children}</div>,
+  DragOverlay: ({ children }: { children: React.ReactNode }) => <div data-testid="drag-overlay">{children}</div>,
+  PointerSensor: vi.fn(),
+  KeyboardSensor: vi.fn(),
+  useSensor: vi.fn(),
+  useSensors: vi.fn(() => []),
+  closestCorners: vi.fn(),
+}));
+
+vi.mock("@dnd-kit/sortable", () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  verticalListSortingStrategy: vi.fn(),
+  sortableKeyboardCoordinates: vi.fn(),
+  useSortable: vi.fn(() => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: null,
+    isDragging: false,
+  })),
+}));
+
+vi.mock("@dnd-kit/utilities", () => ({
+  CSS: { Transform: { toString: vi.fn(() => undefined) } },
+}));
+
+vi.mock("@dnd-kit/core", async () => {
+  const actual = await vi.importActual<typeof import("@dnd-kit/core")>("@dnd-kit/core");
+  return {
+    ...actual,
+    DndContext: ({ children, onDragEnd }: { children: React.ReactNode; onDragEnd?: (e: unknown) => void }) => (
+      <div data-testid="dnd-context" onClick={() => onDragEnd?.({ active: { id: "i1" }, over: { id: "Resolved" } })}>
+        {children}
+      </div>
+    ),
+    DragOverlay: ({ children }: { children: React.ReactNode }) => <div data-testid="drag-overlay">{children}</div>,
+    useSensor: vi.fn(),
+    useSensors: vi.fn(() => []),
+    closestCorners: vi.fn(),
+    PointerSensor: vi.fn(),
+    KeyboardSensor: vi.fn(),
+  };
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+const makeIssue = (overrides?: Partial<IssueDto>): IssueDto => ({
+  id: "i1",
+  title: "Bug crítico no login",
+  description: "Descrição do bug",
+  status: "Open",
+  priority: "High",
+  assigneeName: "Neo",
+  createdAt: "2026-04-01T10:00:00Z",
+  updatedAt: "2026-04-01T10:00:00Z",
+  tags: [],
+  commentsCount: 0,
+  ...overrides,
+});
+
+// ── KanbanCard ────────────────────────────────────────────────────────────
+
+import { KanbanCard } from "@/components/issues/kanban-card";
+
+describe("KanbanCard", () => {
+  it("exibe o título da issue", () => {
+    render(<KanbanCard issue={makeIssue()} />);
+    expect(screen.getByText("Bug crítico no login")).toBeInTheDocument();
+  });
+
+  it("exibe o nome do responsável", () => {
+    render(<KanbanCard issue={makeIssue()} />);
+    expect(screen.getByText("👤 Neo")).toBeInTheDocument();
+  });
+
+  it("não exibe responsável quando não há assigneeName", () => {
+    render(<KanbanCard issue={makeIssue({ assigneeName: undefined })} />);
+    expect(screen.queryByText(/👤/)).not.toBeInTheDocument();
+  });
+
+  it("exibe link para detalhe da issue", () => {
+    render(<KanbanCard issue={makeIssue()} />);
+    const link = screen.getByRole("link", { name: /ver issue/i });
+    expect(link).toHaveAttribute("href", "/issues/i1");
+  });
+
+  it("exibe badge de prioridade", () => {
+    render(<KanbanCard issue={makeIssue({ priority: "Critical" })} />);
+    // PriorityBadge renderiza o texto da prioridade
+    expect(screen.getByText(/critical/i)).toBeInTheDocument();
+  });
+
+  it("aplica classe de overlay quando isOverlay=true", () => {
+    const { container } = render(<KanbanCard issue={makeIssue()} isOverlay />);
+    expect(container.firstChild).toHaveClass("rotate-1");
+  });
+});
+
+// ── KanbanColumn ──────────────────────────────────────────────────────────
+
+import { KanbanColumn } from "@/components/issues/kanban-column";
+
+vi.mock("@dnd-kit/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@dnd-kit/core")>();
+  return {
+    ...actual,
+    useDroppable: vi.fn(() => ({ setNodeRef: vi.fn(), isOver: false })),
+    DndContext: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    DragOverlay: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+    useSensor: vi.fn(),
+    useSensors: vi.fn(() => []),
+    closestCorners: vi.fn(),
+    PointerSensor: vi.fn(),
+    KeyboardSensor: vi.fn(),
+  };
+});
+
+describe("KanbanColumn", () => {
+  it("exibe o label e contagem", () => {
+    render(
+      <KanbanColumn id="Open" label="Aberto" colorClass="border-t-blue-500" count={3}>
+        <div>card</div>
+      </KanbanColumn>
+    );
+    expect(screen.getByText("Aberto")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("exibe os filhos", () => {
+    render(
+      <KanbanColumn id="Open" label="Aberto" colorClass="border-t-blue-500" count={0}>
+        <div data-testid="child-card">Card filho</div>
+      </KanbanColumn>
+    );
+    expect(screen.getByTestId("child-card")).toBeInTheDocument();
+  });
+});
+
+// ── IssuesViewToggle ──────────────────────────────────────────────────────
+
+import { IssuesViewToggle } from "@/components/issues/issues-view-toggle";
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => new URLSearchParams("view=list"),
+}));
+
+describe("IssuesViewToggle", () => {
+  beforeEach(() => mockPush.mockClear());
+
+  it("renderiza os botões Lista e Kanban", () => {
+    render(<IssuesViewToggle />);
+    expect(screen.getByRole("button", { name: /lista/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /kanban/i })).toBeInTheDocument();
+  });
+
+  it("botão Lista está pressionado quando view=list", () => {
+    render(<IssuesViewToggle />);
+    expect(screen.getByRole("button", { name: /lista/i })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: /kanban/i })).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("navega para ?view=kanban ao clicar em Kanban", () => {
+    render(<IssuesViewToggle />);
+    fireEvent.click(screen.getByRole("button", { name: /kanban/i }));
+    expect(mockPush).toHaveBeenCalledWith(expect.stringContaining("view=kanban"));
+  });
+
+  it("navega para ?view=list ao clicar em Lista", () => {
+    render(<IssuesViewToggle />);
+    fireEvent.click(screen.getByRole("button", { name: /lista/i }));
+    expect(mockPush).toHaveBeenCalledWith(expect.stringContaining("view=list"));
+  });
+});

--- a/frontend/apps/next-shell/app/(dashboard)/issues/page.tsx
+++ b/frontend/apps/next-shell/app/(dashboard)/issues/page.tsx
@@ -3,6 +3,9 @@ import type { IssueDto, PagedResult } from "@/lib/types";
 import { StatusBadge, PriorityBadge } from "@/components/badges";
 import Link from "next/link";
 import { Plus, MessageSquare } from "lucide-react";
+import { IssuesViewToggle } from "@/components/issues/issues-view-toggle";
+import { KanbanBoardWrapper } from "@/components/issues/kanban-board-wrapper";
+import { Suspense } from "react";
 
 interface SearchParams {
   page?: string;
@@ -10,12 +13,14 @@ interface SearchParams {
   status?: string;
   priority?: string;
   search?: string;
+  view?: string;
 }
 
 async function getIssues(params: SearchParams) {
+  const isKanban = params.view === "kanban";
   const qs = new URLSearchParams({
     pageNumber: params.page ?? "1",
-    pageSize: params.pageSize ?? "15",
+    pageSize: isKanban ? "100" : (params.pageSize ?? "15"),
     ...(params.status && { status: params.status }),
     ...(params.priority && { priority: params.priority }),
     ...(params.search && { searchTerm: params.search }),
@@ -32,6 +37,7 @@ export default async function IssuesPage({
   searchParams: Promise<SearchParams>;
 }) {
   const params = await searchParams;
+  const isKanban = params.view === "kanban";
   const data = await getIssues(params).catch(() => null);
 
   return (
@@ -43,20 +49,31 @@ export default async function IssuesPage({
             {data ? `${data.totalCount} issues encontradas` : "Carregando..."}
           </p>
         </div>
-        <Link
-          href="/issues/new"
-          className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-500 transition-colors"
-        >
-          <Plus size={16} />
-          Nova Issue
-        </Link>
+        <div className="flex items-center gap-3">
+          <Suspense>
+            <IssuesViewToggle />
+          </Suspense>
+          <Link
+            href="/issues/new"
+            className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-500 transition-colors"
+          >
+            <Plus size={16} />
+            Nova Issue
+          </Link>
+        </div>
       </div>
 
-      {/* Filtros */}
       <IssueFilters current={params} />
 
-      {/* Tabela */}
-      {!data ? (
+      {isKanban ? (
+        !data ? (
+          <div className="bg-(--bg-surface) rounded-xl border border-(--border) p-8 text-center text-(--text-secondary)">
+            Erro ao carregar issues.
+          </div>
+        ) : (
+          <KanbanBoardWrapper issues={data.items} />
+        )
+      ) : !data ? (
         <div className="bg-(--bg-surface) rounded-xl border border-(--border) p-8 text-center text-(--text-secondary)">
           Erro ao carregar issues. Verifique se o servidor está rodando.
         </div>
@@ -110,25 +127,16 @@ export default async function IssuesPage({
             </tbody>
           </table>
 
-          {/* Paginação */}
           <div className="px-4 py-3 border-t border-(--border) flex items-center justify-between text-sm text-(--text-secondary)">
-            <span>
-              Página {data.pageNumber} de {data.totalPages}
-            </span>
+            <span>Página {data.pageNumber} de {data.totalPages}</span>
             <div className="flex gap-2">
               {data.pageNumber > 1 && (
-                <Link
-                  href={`?page=${data.pageNumber - 1}`}
-                  className="px-3 py-1 rounded border border-(--border-input) text-(--text-primary) hover:bg-(--bg-subtle)"
-                >
+                <Link href={`?page=${data.pageNumber - 1}`} className="px-3 py-1 rounded border border-(--border-input) text-(--text-primary) hover:bg-(--bg-subtle)">
                   Anterior
                 </Link>
               )}
               {data.pageNumber < data.totalPages && (
-                <Link
-                  href={`?page=${data.pageNumber + 1}`}
-                  className="px-3 py-1 rounded border border-(--border-input) text-(--text-primary) hover:bg-(--bg-subtle)"
-                >
+                <Link href={`?page=${data.pageNumber + 1}`} className="px-3 py-1 rounded border border-(--border-input) text-(--text-primary) hover:bg-(--bg-subtle)">
                   Próxima
                 </Link>
               )}
@@ -168,10 +176,8 @@ function IssueFilters({ current }: { current: SearchParams }) {
         <option value="">Todas as prioridades</option>
         {priorities.map((p) => <option key={p} value={p}>{p}</option>)}
       </select>
-      <button
-        type="submit"
-        className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-500 transition-colors"
-      >
+      {current.view && <input type="hidden" name="view" value={current.view} />}
+      <button type="submit" className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-500 transition-colors">
         Filtrar
       </button>
     </form>

--- a/frontend/apps/next-shell/components/issues/issues-view-toggle.tsx
+++ b/frontend/apps/next-shell/components/issues/issues-view-toggle.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+/**
+ * issues-view-toggle.tsx — US-062
+ * Client component that switches between List and Kanban views.
+ */
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { LayoutList, LayoutGrid } from "lucide-react";
+
+export function IssuesViewToggle() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const currentView = searchParams.get("view") ?? "list";
+
+  function setView(view: "list" | "kanban") {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set("view", view);
+    router.push(`?${params.toString()}`);
+  }
+
+  return (
+    <div className="flex items-center gap-1 rounded-lg border border-(--border) p-1 bg-(--bg-surface)">
+      <button
+        onClick={() => setView("list")}
+        aria-label="Visualização em lista"
+        aria-pressed={currentView === "list"}
+        className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+          currentView === "list"
+            ? "bg-blue-600 text-white"
+            : "text-(--text-secondary) hover:bg-(--bg-subtle)"
+        }`}
+      >
+        <LayoutList size={14} />
+        Lista
+      </button>
+      <button
+        onClick={() => setView("kanban")}
+        aria-label="Visualização Kanban"
+        aria-pressed={currentView === "kanban"}
+        className={`flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
+          currentView === "kanban"
+            ? "bg-blue-600 text-white"
+            : "text-(--text-secondary) hover:bg-(--bg-subtle)"
+        }`}
+      >
+        <LayoutGrid size={14} />
+        Kanban
+      </button>
+    </div>
+  );
+}

--- a/frontend/apps/next-shell/components/issues/kanban-board-wrapper.tsx
+++ b/frontend/apps/next-shell/components/issues/kanban-board-wrapper.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+/**
+ * kanban-board-wrapper.tsx — US-062
+ * Client wrapper that connects the KanbanBoard to the API.
+ */
+
+import { useCallback } from "react";
+import { KanbanBoard } from "./kanban-board";
+import type { IssueDto, IssueStatus } from "@/lib/types";
+
+interface KanbanBoardWrapperProps {
+  issues: IssueDto[];
+}
+
+export function KanbanBoardWrapper({ issues }: KanbanBoardWrapperProps) {
+  const handleStatusChange = useCallback(
+    async (issueId: string, newStatus: IssueStatus) => {
+      const res = await fetch(`/api/proxy/issues/${issueId}/status`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: newStatus }),
+      });
+      if (!res.ok) throw new Error(`Failed to update status: ${res.status}`);
+    },
+    []
+  );
+
+  return <KanbanBoard issues={issues} onStatusChange={handleStatusChange} />;
+}

--- a/frontend/apps/next-shell/components/issues/kanban-board.tsx
+++ b/frontend/apps/next-shell/components/issues/kanban-board.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+/**
+ * kanban-board.tsx — US-062: Issues Kanban Board view
+ *
+ * Drag-and-drop board with columns per status.
+ * Uses @dnd-kit/core for accessible DnD.
+ */
+
+import { useState, useCallback } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  closestCorners,
+  type DragStartEvent,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  sortableKeyboardCoordinates,
+} from "@dnd-kit/sortable";
+import { KanbanColumn } from "./kanban-column";
+import { KanbanCard } from "./kanban-card";
+import type { IssueDto, IssueStatus } from "@/lib/types";
+
+export const KANBAN_COLUMNS: { id: IssueStatus; label: string; color: string }[] = [
+  { id: "Open", label: "Aberto", color: "border-t-blue-500" },
+  { id: "InProgress", label: "Em Andamento", color: "border-t-yellow-500" },
+  { id: "Resolved", label: "Resolvido", color: "border-t-green-500" },
+  { id: "Closed", label: "Fechado", color: "border-t-gray-400" },
+];
+
+interface KanbanBoardProps {
+  issues: IssueDto[];
+  onStatusChange: (issueId: string, newStatus: IssueStatus) => Promise<void>;
+}
+
+export function KanbanBoard({ issues, onStatusChange }: KanbanBoardProps) {
+  const [activeIssue, setActiveIssue] = useState<IssueDto | null>(null);
+  const [localIssues, setLocalIssues] = useState<IssueDto[]>(issues);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const getIssuesByStatus = useCallback(
+    (status: IssueStatus) => localIssues.filter((i) => i.status === status),
+    [localIssues]
+  );
+
+  function handleDragStart(event: DragStartEvent) {
+    const issue = localIssues.find((i) => i.id === event.active.id);
+    setActiveIssue(issue ?? null);
+  }
+
+  async function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    setActiveIssue(null);
+
+    if (!over) return;
+
+    const draggedIssue = localIssues.find((i) => i.id === active.id);
+    if (!draggedIssue) return;
+
+    // over.id pode ser um column id ou um card id
+    const targetStatus = KANBAN_COLUMNS.find(
+      (col) => col.id === over.id || localIssues.find((i) => i.id === over.id)?.status === col.id
+    );
+
+    const newStatus: IssueStatus =
+      (KANBAN_COLUMNS.find((c) => c.id === over.id)?.id as IssueStatus) ??
+      (localIssues.find((i) => i.id === over.id)?.status as IssueStatus);
+
+    if (!newStatus || newStatus === draggedIssue.status) return;
+
+    // Optimistic update
+    setLocalIssues((prev) =>
+      prev.map((i) => (i.id === draggedIssue.id ? { ...i, status: newStatus } : i))
+    );
+
+    try {
+      await onStatusChange(draggedIssue.id, newStatus);
+    } catch {
+      // Rollback
+      setLocalIssues((prev) =>
+        prev.map((i) =>
+          i.id === draggedIssue.id ? { ...i, status: draggedIssue.status } : i
+        )
+      );
+    }
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCorners}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+    >
+      <div
+        className="grid gap-4"
+        style={{ gridTemplateColumns: `repeat(${KANBAN_COLUMNS.length}, minmax(0, 1fr))` }}
+        role="region"
+        aria-label="Kanban board"
+      >
+        {KANBAN_COLUMNS.map((col) => {
+          const colIssues = getIssuesByStatus(col.id);
+          return (
+            <KanbanColumn
+              key={col.id}
+              id={col.id}
+              label={col.label}
+              colorClass={col.color}
+              count={colIssues.length}
+            >
+              <SortableContext
+                items={colIssues.map((i) => i.id)}
+                strategy={verticalListSortingStrategy}
+              >
+                {colIssues.map((issue) => (
+                  <KanbanCard key={issue.id} issue={issue} />
+                ))}
+              </SortableContext>
+            </KanbanColumn>
+          );
+        })}
+      </div>
+
+      <DragOverlay>
+        {activeIssue && <KanbanCard issue={activeIssue} isOverlay />}
+      </DragOverlay>
+    </DndContext>
+  );
+}

--- a/frontend/apps/next-shell/components/issues/kanban-card.tsx
+++ b/frontend/apps/next-shell/components/issues/kanban-card.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+/**
+ * kanban-card.tsx — US-062
+ * Draggable issue card for the Kanban board.
+ */
+
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import Link from "next/link";
+import { PriorityBadge } from "@/components/badges";
+import type { IssueDto } from "@/lib/types";
+
+const PRIORITY_ORDER = { Critical: 0, High: 1, Medium: 2, Low: 3 };
+
+interface KanbanCardProps {
+  issue: IssueDto;
+  isOverlay?: boolean;
+}
+
+export function KanbanCard({ issue, isOverlay = false }: KanbanCardProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: issue.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      aria-label={`Issue: ${issue.title}`}
+      className={`
+        bg-(--bg-surface) rounded-lg border border-(--border) p-3 cursor-grab active:cursor-grabbing
+        shadow-sm hover:shadow-md transition-shadow select-none
+        ${isDragging ? "opacity-40 ring-2 ring-blue-500" : ""}
+        ${isOverlay ? "shadow-xl rotate-1 opacity-95" : ""}
+      `}
+    >
+      <div className="flex items-start justify-between gap-2 mb-2">
+        <p className="text-xs font-semibold text-(--text-primary) line-clamp-2 flex-1">
+          {issue.title}
+        </p>
+        <PriorityBadge priority={issue.priority} />
+      </div>
+
+      {issue.assigneeName && (
+        <p className="text-xs text-(--text-muted) mt-1 truncate">
+          👤 {issue.assigneeName}
+        </p>
+      )}
+
+      <div className="flex items-center justify-between mt-2">
+        <span className="text-[10px] text-(--text-muted)">
+          {new Date(issue.createdAt).toLocaleDateString("pt-BR")}
+        </span>
+        <Link
+          href={`/issues/${issue.id}`}
+          onClick={(e) => e.stopPropagation()}
+          className="text-[10px] text-blue-600 hover:text-blue-500 font-medium"
+          aria-label={`Ver issue ${issue.title}`}
+        >
+          Ver →
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/apps/next-shell/components/issues/kanban-column.tsx
+++ b/frontend/apps/next-shell/components/issues/kanban-column.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+/**
+ * kanban-column.tsx — US-062
+ * Droppable column container for the Kanban board.
+ */
+
+import { useDroppable } from "@dnd-kit/core";
+import type { IssueStatus } from "@/lib/types";
+
+interface KanbanColumnProps {
+  id: IssueStatus;
+  label: string;
+  colorClass: string;
+  count: number;
+  children: React.ReactNode;
+}
+
+export function KanbanColumn({ id, label, colorClass, count, children }: KanbanColumnProps) {
+  const { setNodeRef, isOver } = useDroppable({ id });
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`
+        flex flex-col rounded-xl border border-(--border) bg-(--bg-subtle)
+        border-t-4 ${colorClass} min-h-32
+        transition-colors ${isOver ? "bg-blue-50 dark:bg-blue-950/20" : ""}
+      `}
+      aria-label={`Coluna ${label}`}
+    >
+      {/* Column header */}
+      <div className="flex items-center justify-between px-3 py-2.5 border-b border-(--border)">
+        <span className="text-sm font-semibold text-(--text-primary)">{label}</span>
+        <span className="text-xs font-medium px-1.5 py-0.5 rounded-full bg-(--bg-surface) text-(--text-secondary) border border-(--border)">
+          {count}
+        </span>
+      </div>
+
+      {/* Cards */}
+      <div className="flex flex-col gap-2 p-2 flex-1">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/apps/next-shell/package-lock.json
+++ b/frontend/apps/next-shell/package-lock.json
@@ -8,6 +8,9 @@
       "name": "next-shell",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^5.2.2",
         "@microsoft/signalr": "^10.0.0",
         "@tanstack/react-query": "^5.99.0",
@@ -515,6 +518,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/frontend/apps/next-shell/package.json
+++ b/frontend/apps/next-shell/package.json
@@ -15,6 +15,9 @@
     "test:e2e:report": "playwright show-report"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^5.2.2",
     "@microsoft/signalr": "^10.0.0",
     "@tanstack/react-query": "^5.99.0",


### PR DESCRIPTION
## Descrição
Implementação completa do Kanban Board para issues com drag-and-drop acessível usando `@dnd-kit`.

## O que foi entregue

### Componentes novos
- `KanbanBoard` — board com 4 colunas (Open, InProgress, Resolved, Closed), DnD com `@dnd-kit/core`
- `KanbanCard` — card arrastável com badge de prioridade, assignee e link para detalhe
- `KanbanColumn` — coluna droppable com header, label e contagem de issues
- `IssuesViewToggle` — toggle Lista/Kanban no header da página (client component)
- `KanbanBoardWrapper` — client wrapper que chama `PATCH /api/issues/{id}/status` ao mover card

### Página atualizada
- `/issues?view=kanban` → renderiza o KanbanBoard
- `/issues` (sem parâmetro) → comportamento original (lista tabular)
- Filtros preservam o parâmetro `view` via hidden input

### UX
- Optimistic update: card move imediatamente, rollback silencioso se o backend falhar
- Acessível via teclado (`KeyboardSensor`)
- `pageSize=100` automaticamente no modo kanban

## Testes
```
✓ __tests__/issues/kanban.test.tsx (12 tests)
  KanbanCard (6): título, assignee, link, prioridade, overlay class
  KanbanColumn (2): label/count, children
  IssuesViewToggle (4): render, aria-pressed, navegação list/kanban

Suite completa: 72 testes passando (era 43 antes da Sprint 7)
```

Closes #85