### PR TITLE
feat(US-091/092): Billing & Subscription + Self-service Tenant Onboarding

### DIFF
--- a/backend/src/Modules/Auth/AuthModuleExtensions.cs
+++ b/backend/src/Modules/Auth/AuthModuleExtensions.cs
@@ -140,8 +140,7 @@ public static class AuthModuleExtensions
     {
         services.AddAuthorization(options =>
         {
-            // Legacy policy — kept for backward compatibility
-            options.AddPolicy("AdminOnly", policy =>
+            options.AddPolicy(Policies.AdminOnly, policy =>
                 policy.RequireRole("Admin"));
 
             // ── US-057: Granular RBAC policies ────────────────────────────────

--- a/backend/src/Modules/Billing/Api/BillingModule.cs
+++ b/backend/src/Modules/Billing/Api/BillingModule.cs
@@ -1,0 +1,124 @@
+using IMS.Modular.Modules.Billing.Application.DTOs;
+using IMS.Modular.Modules.Billing.Application.Services;
+using IMS.Modular.Modules.Billing.Infrastructure;
+using IMS.Modular.Shared.Abstractions;
+using IMS.Modular.Shared.MultiTenancy;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace IMS.Modular.Modules.Billing.Api;
+
+/// <summary>
+/// US-091: Billing API endpoints.
+/// </summary>
+public static class BillingModule
+{
+    public static void Map(WebApplication app)
+    {
+        var group = app
+            .MapGroup("/api/billing")
+            .WithTags("Billing");
+
+        // Public — list active plans
+        group.MapGet("/plans", GetPlans)
+            .WithName("GetBillingPlans")
+            .AllowAnonymous();
+
+        // Authenticated — get current tenant's subscription summary
+        group.MapGet("/subscription", GetSubscription)
+            .WithName("GetSubscription")
+            .RequireAuthorization();
+
+        // Admin only — override plan for any tenant
+        group.MapPost("/admin/override", OverridePlan)
+            .WithName("OverridePlan")
+            .RequireAuthorization(Policies.AdminOnly);
+
+        // Authenticated — create Stripe checkout session
+        group.MapPost("/checkout", CreateCheckout)
+            .WithName("CreateBillingCheckout")
+            .RequireAuthorization();
+
+        // Anonymous — Stripe webhook handler
+        group.MapPost("/webhook", HandleWebhook)
+            .WithName("BillingWebhook")
+            .AllowAnonymous();
+    }
+
+    private static async Task<IResult> GetPlans(BillingDbContext db, CancellationToken ct)
+    {
+        var plans = await db.Plans
+            .Where(p => p.IsActive)
+            .OrderBy(p => p.PriceMonthly)
+            .Select(p => new PlanDto(p.Id, p.Name, p.Description,
+                p.MaxIssuesPerMonth, p.MaxUsers, p.MaxTenants, p.PriceMonthly, p.IsActive))
+            .ToListAsync(ct);
+        return Results.Ok(plans);
+    }
+
+    private static async Task<IResult> GetSubscription(
+        IBillingService billingService,
+        ITenantService tenantService,
+        CancellationToken ct)
+    {
+        var tenantId = tenantService.TenantId ?? "default";
+        var summary = await billingService.GetSubscriptionAsync(tenantId);
+
+        if (summary is null)
+        {
+            await billingService.GetOrCreateSubscriptionAsync(tenantId);
+            summary = await billingService.GetSubscriptionAsync(tenantId);
+        }
+
+        return Results.Ok(summary);
+    }
+
+    private static async Task<IResult> OverridePlan(
+        [FromBody] OverridePlanRequest request,
+        IBillingService billingService,
+        CancellationToken ct)
+    {
+        await billingService.OverridePlanAsync(request.TenantId, request.PlanId);
+        return Results.NoContent();
+    }
+
+    private static async Task<IResult> CreateCheckout(
+        [FromBody] CreateCheckoutRequest request,
+        IStripeService stripeService,
+        ITenantService tenantService,
+        HttpContext httpContext,
+        CancellationToken ct)
+    {
+        var tenantId = tenantService.TenantId ?? "default";
+        var baseUrl = $"{httpContext.Request.Scheme}://{httpContext.Request.Host}";
+        var url = await stripeService.CreateCheckoutSessionAsync(
+            tenantId,
+            request.PlanId,
+            successUrl: $"{baseUrl}/billing/success",
+            cancelUrl: $"{baseUrl}/billing/cancel");
+
+        if (url is null)
+            return Results.Problem(
+                detail: "Stripe is not configured. Set FeatureManagement:UseStripe=true and provide Stripe credentials.",
+                statusCode: StatusCodes.Status501NotImplemented,
+                title: "Stripe Not Configured");
+
+        return Results.Ok(new { CheckoutUrl = url });
+    }
+
+    private static async Task<IResult> HandleWebhook(
+        IStripeService stripeService,
+        HttpContext httpContext,
+        CancellationToken ct)
+    {
+        using var reader = new StreamReader(httpContext.Request.Body);
+        var payload = await reader.ReadToEndAsync(ct);
+        var signature = httpContext.Request.Headers["Stripe-Signature"].ToString();
+
+        await stripeService.HandleWebhookAsync(payload, signature);
+        return Results.Ok();
+    }
+}
+
+public record OverridePlanRequest(string TenantId, string PlanId);
+public record CreateCheckoutRequest(string PlanId);

--- a/backend/src/Modules/Billing/Application/Behaviors/QuotaBehavior.cs
+++ b/backend/src/Modules/Billing/Application/Behaviors/QuotaBehavior.cs
@@ -1,0 +1,37 @@
+using IMS.Modular.Modules.Billing.Application.Interfaces;
+using IMS.Modular.Modules.Billing.Application.Services;
+using IMS.Modular.Shared.Abstractions;
+using IMS.Modular.Shared.MultiTenancy;
+using MediatR;
+
+namespace IMS.Modular.Modules.Billing.Application.Behaviors;
+
+/// <summary>
+/// US-091: MediatR pipeline behavior that enforces billing quota on commands
+/// that implement IRequiresQuota. Runs after ValidationBehavior.
+/// </summary>
+public sealed class QuotaBehavior<TRequest, TResponse>(
+    ITenantService tenantService,
+    IBillingService billingService)
+    : IPipelineBehavior<TRequest, TResponse>
+    where TRequest : IRequest<TResponse>
+{
+    public async Task<TResponse> Handle(
+        TRequest request,
+        RequestHandlerDelegate<TResponse> next,
+        CancellationToken cancellationToken)
+    {
+        if (request is not IRequiresQuota quotaRequest)
+            return await next();
+
+        var tenantId = tenantService.TenantId;
+        if (string.IsNullOrEmpty(tenantId))
+            return await next();
+
+        var allowed = await billingService.CheckQuotaAsync(tenantId, quotaRequest.ResourceType);
+        if (!allowed)
+            throw new QuotaExceededException(quotaRequest.ResourceType, tenantId);
+
+        return await next();
+    }
+}

--- a/backend/src/Modules/Billing/Application/DTOs/BillingDtos.cs
+++ b/backend/src/Modules/Billing/Application/DTOs/BillingDtos.cs
@@ -1,0 +1,32 @@
+namespace IMS.Modular.Modules.Billing.Application.DTOs;
+
+public record PlanDto(
+    string Id,
+    string Name,
+    string Description,
+    int? MaxIssuesPerMonth,
+    int? MaxUsers,
+    int? MaxTenants,
+    decimal PriceMonthly,
+    bool IsActive);
+
+public record UsageDto(
+    string ResourceType,
+    int Count,
+    int? Limit,
+    int Year,
+    int Month);
+
+public record SubscriptionDto(
+    Guid Id,
+    string TenantId,
+    string PlanId,
+    string Status,
+    DateTime StartedAt,
+    DateTime? CancelledAt,
+    DateTime? CurrentPeriodEnd);
+
+public record SubscriptionSummaryDto(
+    SubscriptionDto Subscription,
+    PlanDto Plan,
+    IReadOnlyList<UsageDto> Usage);

--- a/backend/src/Modules/Billing/Application/Interfaces/IRequiresQuota.cs
+++ b/backend/src/Modules/Billing/Application/Interfaces/IRequiresQuota.cs
@@ -1,0 +1,11 @@
+namespace IMS.Modular.Modules.Billing.Application.Interfaces;
+
+/// <summary>
+/// US-091: Marker interface for MediatR commands that require quota enforcement.
+/// Commands implementing this interface will be checked against the tenant's plan limits
+/// by QuotaBehavior before the handler executes.
+/// </summary>
+public interface IRequiresQuota
+{
+    string ResourceType => "issues";
+}

--- a/backend/src/Modules/Billing/Application/Services/BillingService.cs
+++ b/backend/src/Modules/Billing/Application/Services/BillingService.cs
@@ -1,0 +1,152 @@
+using IMS.Modular.Modules.Billing.Application.DTOs;
+using IMS.Modular.Modules.Billing.Domain.Entities;
+using IMS.Modular.Modules.Billing.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace IMS.Modular.Modules.Billing.Application.Services;
+
+/// <summary>
+/// US-091: Core billing service — manages subscriptions, plans, and usage quotas.
+/// </summary>
+public sealed class BillingService(BillingDbContext db) : IBillingService
+{
+    public async Task<SubscriptionSummaryDto?> GetSubscriptionAsync(string tenantId)
+    {
+        var subscription = await db.Subscriptions
+            .Include(s => s.Plan)
+            .FirstOrDefaultAsync(s => s.TenantId == tenantId && s.Status == "active");
+
+        if (subscription is null) return null;
+
+        var now = DateTime.UtcNow;
+        var usageRecords = await db.UsageRecords
+            .Where(u => u.TenantId == tenantId && u.Year == now.Year && u.Month == now.Month)
+            .ToListAsync();
+
+        var usageDtos = usageRecords.Select(u => new UsageDto(
+            u.ResourceType,
+            u.Count,
+            GetLimit(subscription.Plan, u.ResourceType),
+            u.Year,
+            u.Month)).ToList();
+
+        return new SubscriptionSummaryDto(
+            MapSubscription(subscription),
+            MapPlan(subscription.Plan),
+            usageDtos);
+    }
+
+    public async Task<bool> CheckQuotaAsync(string tenantId, string resourceType)
+    {
+        var subscription = await GetOrCreateSubscriptionAsync(tenantId);
+        var plan = subscription.Plan;
+
+        if (resourceType == "issues")
+        {
+            if (plan.MaxIssuesPerMonth is null) return true; // unlimited
+
+            var now = DateTime.UtcNow;
+            var usage = await db.UsageRecords.FirstOrDefaultAsync(u =>
+                u.TenantId == tenantId && u.ResourceType == resourceType &&
+                u.Year == now.Year && u.Month == now.Month);
+
+            var count = usage?.Count ?? 0;
+            return count < plan.MaxIssuesPerMonth.Value;
+        }
+
+        return true;
+    }
+
+    public async Task IncrementUsageAsync(string tenantId, string resourceType)
+    {
+        var now = DateTime.UtcNow;
+        var usage = await db.UsageRecords.FirstOrDefaultAsync(u =>
+            u.TenantId == tenantId && u.ResourceType == resourceType &&
+            u.Year == now.Year && u.Month == now.Month);
+
+        if (usage is null)
+        {
+            usage = new UsageRecord
+            {
+                TenantId = tenantId,
+                ResourceType = resourceType,
+                Count = 1,
+                Year = now.Year,
+                Month = now.Month
+            };
+            db.UsageRecords.Add(usage);
+        }
+        else
+        {
+            usage.Count++;
+            usage.LastUpdatedAt = now;
+        }
+
+        await db.SaveChangesAsync();
+    }
+
+    public async Task<Subscription> GetOrCreateSubscriptionAsync(string tenantId, string planId = "free")
+    {
+        var subscription = await db.Subscriptions
+            .Include(s => s.Plan)
+            .FirstOrDefaultAsync(s => s.TenantId == tenantId && s.Status == "active");
+
+        if (subscription is not null) return subscription;
+
+        subscription = new Subscription
+        {
+            TenantId = tenantId,
+            PlanId = planId,
+            Status = "active"
+        };
+        db.Subscriptions.Add(subscription);
+        await db.SaveChangesAsync();
+
+        await db.Entry(subscription).Reference(s => s.Plan).LoadAsync();
+        return subscription;
+    }
+
+    public async Task OverridePlanAsync(string tenantId, string planId)
+    {
+        var plan = await db.Plans.FindAsync(planId)
+            ?? throw new KeyNotFoundException($"Plan '{planId}' not found.");
+
+        var subscription = await db.Subscriptions
+            .FirstOrDefaultAsync(s => s.TenantId == tenantId && s.Status == "active");
+
+        if (subscription is null)
+        {
+            subscription = new Subscription
+            {
+                TenantId = tenantId,
+                PlanId = planId,
+                Status = "active"
+            };
+            db.Subscriptions.Add(subscription);
+        }
+        else
+        {
+            subscription.PlanId = planId;
+        }
+
+        await db.SaveChangesAsync();
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static int? GetLimit(Plan plan, string resourceType) => resourceType switch
+    {
+        "issues" => plan.MaxIssuesPerMonth,
+        "users"  => plan.MaxUsers,
+        _        => null
+    };
+
+    private static SubscriptionDto MapSubscription(Subscription s) => new(
+        s.Id, s.TenantId, s.PlanId, s.Status,
+        s.StartedAt, s.CancelledAt, s.CurrentPeriodEnd);
+
+    private static PlanDto MapPlan(Plan p) => new(
+        p.Id, p.Name, p.Description,
+        p.MaxIssuesPerMonth, p.MaxUsers, p.MaxTenants,
+        p.PriceMonthly, p.IsActive);
+}

--- a/backend/src/Modules/Billing/Application/Services/IBillingService.cs
+++ b/backend/src/Modules/Billing/Application/Services/IBillingService.cs
@@ -1,0 +1,13 @@
+using IMS.Modular.Modules.Billing.Application.DTOs;
+using IMS.Modular.Modules.Billing.Domain.Entities;
+
+namespace IMS.Modular.Modules.Billing.Application.Services;
+
+public interface IBillingService
+{
+    Task<SubscriptionSummaryDto?> GetSubscriptionAsync(string tenantId);
+    Task<bool> CheckQuotaAsync(string tenantId, string resourceType);
+    Task IncrementUsageAsync(string tenantId, string resourceType);
+    Task<Subscription> GetOrCreateSubscriptionAsync(string tenantId, string planId = "free");
+    Task OverridePlanAsync(string tenantId, string planId);
+}

--- a/backend/src/Modules/Billing/Application/Services/IStripeService.cs
+++ b/backend/src/Modules/Billing/Application/Services/IStripeService.cs
@@ -1,0 +1,20 @@
+namespace IMS.Modular.Modules.Billing.Application.Services;
+
+public interface IStripeService
+{
+    Task<string?> CreateCheckoutSessionAsync(string tenantId, string planId, string successUrl, string cancelUrl);
+    Task<string?> CreateCustomerPortalSessionAsync(string stripeCustomerId, string returnUrl);
+    Task HandleWebhookAsync(string payload, string signature);
+}
+
+public sealed class NoOpStripeService : IStripeService
+{
+    public Task<string?> CreateCheckoutSessionAsync(string tenantId, string planId, string successUrl, string cancelUrl)
+        => Task.FromResult<string?>(null);
+
+    public Task<string?> CreateCustomerPortalSessionAsync(string stripeCustomerId, string returnUrl)
+        => Task.FromResult<string?>(null);
+
+    public Task HandleWebhookAsync(string payload, string signature)
+        => Task.CompletedTask;
+}

--- a/backend/src/Modules/Billing/BillingModuleExtensions.cs
+++ b/backend/src/Modules/Billing/BillingModuleExtensions.cs
@@ -1,0 +1,47 @@
+using IMS.Modular.Modules.Billing.Application.Services;
+using IMS.Modular.Modules.Billing.Infrastructure;
+using IMS.Modular.Shared.Database;
+using IMS.Modular.Shared.FeatureFlags;
+using Microsoft.EntityFrameworkCore;
+
+namespace IMS.Modular.Modules.Billing;
+
+/// <summary>
+/// US-091: DI registration and initialization for the Billing module.
+/// </summary>
+public static class BillingModuleExtensions
+{
+    public static IServiceCollection AddBillingModule(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        IWebHostEnvironment environment)
+    {
+        services.AddDbContext<BillingDbContext>((sp, options) =>
+        {
+            var env = sp.GetRequiredService<IWebHostEnvironment>();
+            options.UseImsDatabase(configuration, env);
+        });
+
+        services.AddScoped<IBillingService, BillingService>();
+
+        // Register Stripe service — real or no-op based on feature flag.
+        // Feature flag is read from configuration at startup (IFeatureManager is scoped/async
+        // and cannot be used at registration time, so we read IConfiguration directly).
+        var useStripe = configuration.GetValue<bool>($"FeatureManagement:{FeatureFlags.UseStripe}");
+        if (useStripe)
+        {
+            // Real Stripe integration would be registered here (e.g., StripeService).
+            // For now, fall through to NoOp since Stripe SDK is not yet a dependency.
+            services.AddScoped<IStripeService, NoOpStripeService>();
+        }
+        else
+        {
+            services.AddScoped<IStripeService, NoOpStripeService>();
+        }
+
+        return services;
+    }
+
+    public static async Task InitializeBillingModuleAsync(this IServiceProvider services)
+        => await services.ApplyMigrationsAsync<BillingDbContext>();
+}

--- a/backend/src/Modules/Billing/Domain/Entities/BillingEntities.cs
+++ b/backend/src/Modules/Billing/Domain/Entities/BillingEntities.cs
@@ -1,0 +1,38 @@
+namespace IMS.Modular.Modules.Billing.Domain.Entities;
+
+public class Plan
+{
+    public string Id { get; set; } = null!;           // "free" | "pro" | "enterprise"
+    public string Name { get; set; } = null!;
+    public string Description { get; set; } = null!;
+    public int? MaxIssuesPerMonth { get; set; }       // null = unlimited
+    public int? MaxUsers { get; set; }
+    public int? MaxTenants { get; set; }
+    public decimal PriceMonthly { get; set; }
+    public bool IsActive { get; set; } = true;
+}
+
+public class Subscription
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string TenantId { get; set; } = null!;
+    public string PlanId { get; set; } = null!;
+    public Plan Plan { get; set; } = null!;
+    public string Status { get; set; } = "active";
+    public DateTime StartedAt { get; set; } = DateTime.UtcNow;
+    public DateTime? CancelledAt { get; set; }
+    public string? StripeSubscriptionId { get; set; }
+    public string? StripeCustomerId { get; set; }
+    public DateTime? CurrentPeriodEnd { get; set; }
+}
+
+public class UsageRecord
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public string TenantId { get; set; } = null!;
+    public string ResourceType { get; set; } = null!;  // "issues" | "users"
+    public int Count { get; set; }
+    public int Year { get; set; }
+    public int Month { get; set; }
+    public DateTime LastUpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/backend/src/Modules/Billing/Infrastructure/BillingDbContext.cs
+++ b/backend/src/Modules/Billing/Infrastructure/BillingDbContext.cs
@@ -1,0 +1,99 @@
+using IMS.Modular.Modules.Billing.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace IMS.Modular.Modules.Billing.Infrastructure;
+
+/// <summary>
+/// US-091: System-level DbContext for Billing module.
+/// Not tenant-aware — manages Plans, Subscriptions (per-tenant), and UsageRecords.
+/// </summary>
+public class BillingDbContext(DbContextOptions<BillingDbContext> options) : DbContext(options)
+{
+    public DbSet<Plan> Plans => Set<Plan>();
+    public DbSet<Subscription> Subscriptions => Set<Subscription>();
+    public DbSet<UsageRecord> UsageRecords => Set<UsageRecord>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        // ── Plan ─────────────────────────────────────────────────────────────
+        modelBuilder.Entity<Plan>(entity =>
+        {
+            entity.ToTable("BillingPlans");
+            entity.HasKey(p => p.Id);
+            entity.Property(p => p.Id).HasMaxLength(50);
+            entity.Property(p => p.Name).IsRequired().HasMaxLength(100);
+            entity.Property(p => p.Description).HasMaxLength(500);
+            entity.Property(p => p.PriceMonthly).HasColumnType("decimal(18,2)");
+            entity.Property(p => p.IsActive).HasDefaultValue(true);
+
+            entity.HasData(
+                new Plan
+                {
+                    Id = "free",
+                    Name = "Free",
+                    Description = "Up to 50 issues/month, 1 tenant",
+                    MaxIssuesPerMonth = 50,
+                    MaxUsers = null,
+                    MaxTenants = 1,
+                    PriceMonthly = 0m,
+                    IsActive = true
+                },
+                new Plan
+                {
+                    Id = "pro",
+                    Name = "Pro",
+                    Description = "Unlimited issues, up to 5 users",
+                    MaxIssuesPerMonth = null,
+                    MaxUsers = 5,
+                    MaxTenants = null,
+                    PriceMonthly = 49m,
+                    IsActive = true
+                },
+                new Plan
+                {
+                    Id = "enterprise",
+                    Name = "Enterprise",
+                    Description = "Unlimited everything — custom pricing",
+                    MaxIssuesPerMonth = null,
+                    MaxUsers = null,
+                    MaxTenants = null,
+                    PriceMonthly = 0m,
+                    IsActive = true
+                });
+        });
+
+        // ── Subscription ─────────────────────────────────────────────────────
+        modelBuilder.Entity<Subscription>(entity =>
+        {
+            entity.ToTable("BillingSubscriptions");
+            entity.HasKey(s => s.Id);
+            entity.Property(s => s.TenantId).IsRequired().HasMaxLength(100);
+            entity.Property(s => s.PlanId).IsRequired().HasMaxLength(50);
+            entity.Property(s => s.Status).IsRequired().HasMaxLength(50);
+            entity.Property(s => s.StripeSubscriptionId).HasMaxLength(200);
+            entity.Property(s => s.StripeCustomerId).HasMaxLength(200);
+
+            entity.HasOne(s => s.Plan)
+                  .WithMany()
+                  .HasForeignKey(s => s.PlanId)
+                  .OnDelete(DeleteBehavior.Restrict);
+
+            entity.HasIndex(s => s.TenantId);
+            entity.HasIndex(s => new { s.TenantId, s.Status });
+        });
+
+        // ── UsageRecord ───────────────────────────────────────────────────────
+        modelBuilder.Entity<UsageRecord>(entity =>
+        {
+            entity.ToTable("BillingUsageRecords");
+            entity.HasKey(u => u.Id);
+            entity.Property(u => u.TenantId).IsRequired().HasMaxLength(100);
+            entity.Property(u => u.ResourceType).IsRequired().HasMaxLength(50);
+
+            entity.HasIndex(u => u.TenantId);
+            entity.HasIndex(u => new { u.TenantId, u.ResourceType, u.Year, u.Month }).IsUnique();
+        });
+    }
+}

--- a/backend/src/Modules/Issues/Application/Commands/IssueCommands.cs
+++ b/backend/src/Modules/Issues/Application/Commands/IssueCommands.cs
@@ -1,3 +1,4 @@
+using IMS.Modular.Modules.Billing.Application.Interfaces;
 using IMS.Modular.Modules.Issues.Application.DTOs;
 using IMS.Modular.Modules.Issues.Domain.Enums;
 using IMS.Modular.Shared.Domain;
@@ -7,7 +8,7 @@ namespace IMS.Modular.Modules.Issues.Application.Commands;
 
 public record CreateIssueCommand(
     string Title, string Description, IssuePriority Priority,
-    Guid ReporterId, DateTime? DueDate) : IRequest<Result<IssueDto>>;
+    Guid ReporterId, DateTime? DueDate) : IRequest<Result<IssueDto>>, IRequiresQuota;
 
 public record UpdateIssueCommand(
     Guid Id, string? Title, string? Description,

--- a/backend/src/Modules/Jobs/JobsModuleExtensions.cs
+++ b/backend/src/Modules/Jobs/JobsModuleExtensions.cs
@@ -4,6 +4,7 @@ using Hangfire.InMemory;
 using Hangfire.PostgreSql;
 using IMS.Modular.Shared.Abstractions;
 using IMS.Modular.Shared.MultiTenancy;
+using IMS.Modular.Shared.MultiTenancy.TenantManagement;
 
 namespace IMS.Modular.Modules.Jobs;
 
@@ -29,6 +30,8 @@ public static class JobsModuleExtensions
         services.AddScoped<AuditLogRetentionJob>();
         // US-088: Meilisearch reindex job
         services.AddScoped<MeilisearchReindexJob>();
+        // US-092: Tenant provisioning job (fire-and-forget, queued during self-service signup)
+        services.AddScoped<TenantProvisioningJob>();
 
         // Configurar Hangfire storage
         services.AddHangfire(config =>

--- a/backend/src/Program.cs
+++ b/backend/src/Program.cs
@@ -8,6 +8,9 @@ using IMS.Modular.Modules.Analytics.Api;
 using IMS.Modular.Modules.Audit;
 using IMS.Modular.Modules.Auth;
 using IMS.Modular.Modules.Auth.Api;
+using IMS.Modular.Modules.Billing;
+using IMS.Modular.Modules.Billing.Api;
+using IMS.Modular.Modules.Billing.Application.Behaviors;
 using IMS.Modular.Modules.Features.Api;
 using IMS.Modular.Modules.Search;
 using IMS.Modular.Modules.Search.Api;
@@ -102,8 +105,9 @@ builder.Services.AddMediatR(cfg =>
 {
     cfg.RegisterServicesFromAssembly(typeof(Program).Assembly);
 
-    // Pipeline Behaviors (order matters: Validation → Logging → Caching → Handler)
+    // Pipeline Behaviors (order matters: Validation → Quota → Logging → Caching → Handler)
     cfg.AddBehavior(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
+    cfg.AddBehavior(typeof(IPipelineBehavior<,>), typeof(QuotaBehavior<,>));
     cfg.AddBehavior(typeof(IPipelineBehavior<,>), typeof(LoggingBehavior<,>));
     cfg.AddBehavior(typeof(IPipelineBehavior<,>), typeof(CachingBehavior<,>));
 });
@@ -171,6 +175,9 @@ builder.Services.AddAuditModule(builder.Configuration, builder.Environment);
 
 // US-071: Full-text Search (Meilisearch)
 builder.Services.AddSearchModule(builder.Configuration);
+
+// US-091: Billing & Subscription
+builder.Services.AddBillingModule(builder.Configuration, builder.Environment);
 
 // US-079: YARP proxy for Issues microservice (only active when UseIssuesMicroservice flag is on)
 builder.Services.AddIssuesProxy(builder.Configuration);
@@ -302,6 +309,8 @@ NotificationsModule.Map(app);
 app.MapWebhooksModule();
 SearchModule.Map(app);
 FeaturesModule.Map(app);
+// US-091: Billing & Subscription
+BillingModule.Map(app);
 // US-080: Tenant management API
 TenantEndpoints.Map(app);
 
@@ -334,6 +343,7 @@ try
     await app.Services.InitializeNotificationsModuleAsync();
     await app.Services.InitializeWebhooksModuleAsync();
     await app.Services.InitializeSearchModuleAsync();
+    await app.Services.InitializeBillingModuleAsync();   // US-091
 }
 catch (Exception ex)
 {

--- a/backend/src/Shared/Abstractions/Policies.cs
+++ b/backend/src/Shared/Abstractions/Policies.cs
@@ -27,4 +27,8 @@ public static class Policies
     // ── Analytics ────────────────────────────────────────────────────────
     /// <summary>Admin and Manager can view analytics dashboards and export data.</summary>
     public const string CanViewAnalytics = "CanViewAnalytics";
+
+    // ── Admin ─────────────────────────────────────────────────────────────────
+    /// <summary>Only Admin role can perform this action.</summary>
+    public const string AdminOnly = "AdminOnly";
 }

--- a/backend/src/Shared/Abstractions/QuotaExceededException.cs
+++ b/backend/src/Shared/Abstractions/QuotaExceededException.cs
@@ -1,0 +1,19 @@
+namespace IMS.Modular.Shared.Abstractions;
+
+/// <summary>
+/// US-091: Thrown when a tenant exceeds their plan quota for a resource type.
+/// Placed in Shared.Abstractions so ExceptionHandlingMiddleware can reference it
+/// without creating a dependency on the Billing module.
+/// </summary>
+public sealed class QuotaExceededException : Exception
+{
+    public string ResourceType { get; }
+    public string TenantId { get; }
+
+    public QuotaExceededException(string resourceType, string tenantId)
+        : base($"Quota exceeded for resource '{resourceType}' on tenant '{tenantId}'. Please upgrade your plan.")
+    {
+        ResourceType = resourceType;
+        TenantId = tenantId;
+    }
+}

--- a/backend/src/Shared/Errors/ExceptionHandlingMiddleware.cs
+++ b/backend/src/Shared/Errors/ExceptionHandlingMiddleware.cs
@@ -152,6 +152,13 @@ public sealed class ExceptionHandlingMiddleware
                 "Client Closed Request",
                 "The request was cancelled by the client."),
 
+            // Quota exceeded → 402
+            QuotaExceededException ex => (
+                StatusCodes.Status402PaymentRequired,
+                "QUOTA_EXCEEDED",
+                "Payment Required",
+                ex.Message),
+
             // Everything else → 500
             _ => (
                 StatusCodes.Status500InternalServerError,

--- a/backend/src/Shared/FeatureFlags/FeatureFlags.cs
+++ b/backend/src/Shared/FeatureFlags/FeatureFlags.cs
@@ -13,4 +13,6 @@ public static class FeatureFlags
     public const string EnableMultiTenancy    = nameof(EnableMultiTenancy);
     /// <summary>US-090: Delegates authentication to Keycloak via OIDC. When false, falls back to custom JWT auth.</summary>
     public const string UseKeycloak           = nameof(UseKeycloak);
+    /// <summary>US-091: Enables real Stripe integration. When false, uses NoOpStripeService.</summary>
+    public const string UseStripe             = nameof(UseStripe);
 }

--- a/backend/src/Shared/MultiTenancy/TenantManagement/SignupRequest.cs
+++ b/backend/src/Shared/MultiTenancy/TenantManagement/SignupRequest.cs
@@ -1,0 +1,41 @@
+using FluentValidation;
+
+namespace IMS.Modular.Shared.MultiTenancy.TenantManagement;
+
+/// <summary>
+/// US-092: Body for the self-service tenant signup endpoint (POST /api/tenants/signup).
+/// </summary>
+public record SignupRequest(
+    string OrgName,
+    string Email,
+    string Password,
+    string Plan);
+
+/// <summary>
+/// US-092: FluentValidation validator for <see cref="SignupRequest"/>.
+/// </summary>
+public sealed class SignupValidator : AbstractValidator<SignupRequest>
+{
+    private static readonly string[] ValidPlans = ["free", "starter", "pro"];
+
+    public SignupValidator()
+    {
+        RuleFor(x => x.OrgName)
+            .NotEmpty().WithMessage("Org name is required.")
+            .MinimumLength(3).WithMessage("Org name must be at least 3 characters.")
+            .MaximumLength(50).WithMessage("Org name cannot exceed 50 characters.");
+
+        RuleFor(x => x.Email)
+            .NotEmpty().WithMessage("Email is required.")
+            .EmailAddress().WithMessage("A valid email address is required.");
+
+        RuleFor(x => x.Password)
+            .NotEmpty().WithMessage("Password is required.")
+            .MinimumLength(8).WithMessage("Password must be at least 8 characters.");
+
+        RuleFor(x => x.Plan)
+            .NotEmpty().WithMessage("Plan is required.")
+            .Must(p => ValidPlans.Contains(p, StringComparer.OrdinalIgnoreCase))
+            .WithMessage("Plan must be one of: free, starter, pro.");
+    }
+}

--- a/backend/src/Shared/MultiTenancy/TenantManagement/TenantEndpoints.cs
+++ b/backend/src/Shared/MultiTenancy/TenantManagement/TenantEndpoints.cs
@@ -1,8 +1,15 @@
-using IMS.Modular.Shared.MultiTenancy.TenantManagement;
+using IMS.Modular.Modules.Auth.Domain.Entities;
+using IMS.Modular.Modules.Auth.Infrastructure;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+using FluentValidation;
+using Hangfire;
+using IMS.Modular.Shared.RateLimiting;
 
 namespace IMS.Modular.Shared.MultiTenancy.TenantManagement;
 
@@ -105,6 +112,121 @@ public static class TenantEndpoints
             return Results.NoContent();
         })
         .WithName("DeactivateTenant");
+
+        // ── US-092: Self-service tenant signup (public, rate-limited) ────────
+
+        app.MapPost("/api/tenants/signup", async (
+            SignupRequest req,
+            TenantDbContext tenantDb,
+            AuthDbContext authDb,
+            IValidator<SignupRequest> validator,
+            IBackgroundJobClient jobClient) =>
+        {
+            // Validate request body
+            var validation = await validator.ValidateAsync(req);
+            if (!validation.IsValid)
+                return Results.ValidationProblem(validation.ToDictionary());
+
+            // Generate tenant slug from org name
+            var slug = GenerateTenantSlug(req.OrgName);
+            if (string.IsNullOrEmpty(slug))
+                return Results.BadRequest(new { message = "Org name could not be converted to a valid tenant ID." });
+
+            // Conflict check
+            if (await tenantDb.Tenants.AnyAsync(t => t.Id == slug))
+                return Results.Conflict(new { message = $"Tenant '{slug}' already exists." });
+
+            // Create tenant (inactive until provisioning completes)
+            var tenant = new TenantEntity
+            {
+                Id = slug,
+                Name = req.OrgName.Trim(),
+                Plan = req.Plan.ToLowerInvariant(),
+                ContactEmail = req.Email.Trim(),
+                IsActive = false,
+                CreatedAt = DateTime.UtcNow,
+                Notes = "Provisioning"
+            };
+            tenantDb.Tenants.Add(tenant);
+
+            // Create admin user in AuthDbContext
+            var username = BuildUsername(slug);
+            if (!await authDb.Users.AnyAsync(u => u.Username == username || u.Email == req.Email))
+            {
+                var adminRole = await authDb.Roles.FirstOrDefaultAsync(r => r.Name == "Admin");
+                var newUser = new User
+                {
+                    Username = username,
+                    Email = req.Email.Trim(),
+                    PasswordHash = HashPassword(req.Password),
+                    FullName = req.OrgName.Trim(),
+                    IsActive = true,
+                    TenantId = slug
+                };
+                authDb.Users.Add(newUser);
+                if (adminRole is not null)
+                    authDb.UserRoles.Add(new UserRole
+                    {
+                        UserId = newUser.Id,
+                        RoleId = adminRole.Id
+                    });
+            }
+
+            await tenantDb.SaveChangesAsync();
+            await authDb.SaveChangesAsync();
+
+            // Queue the background provisioning job
+            jobClient.Enqueue<TenantProvisioningJob>(job =>
+                job.ExecuteAsync(slug, req.Plan.ToLowerInvariant(), req.Email.Trim()));
+
+            return Results.Accepted(null, new
+            {
+                tenantId = slug,
+                message = "Provisioning started. Check your email."
+            });
+        })
+        .WithTags("Tenants")
+        .WithName("SignupTenant")
+        .WithSummary("US-092: Self-service tenant signup (public)")
+        .RequireRateLimiting(RateLimitingExtensions.Policies.Signup)
+        .AllowAnonymous();
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Converts an org name to a URL-safe tenant slug:
+    /// lowercase, alphanumeric + dashes only, max 50 chars.
+    /// </summary>
+    private static string GenerateTenantSlug(string orgName)
+    {
+        var slug = orgName.ToLowerInvariant().Trim();
+        // Replace spaces (and sequences of spaces) with a single dash
+        slug = Regex.Replace(slug, @"\s+", "-");
+        // Remove any character that is not alphanumeric or a dash
+        slug = Regex.Replace(slug, @"[^a-z0-9\-]", "");
+        // Collapse multiple consecutive dashes
+        slug = Regex.Replace(slug, @"-{2,}", "-");
+        // Trim leading/trailing dashes
+        slug = slug.Trim('-');
+        return slug.Length > 50 ? slug[..50] : slug;
+    }
+
+    /// <summary>
+    /// Derives a unique username from the tenant slug (matches ^[a-zA-Z0-9_]+$).
+    /// </summary>
+    private static string BuildUsername(string slug)
+    {
+        var sanitised = slug.Replace("-", "_");
+        var candidate = $"admin_{sanitised}";
+        return candidate.Length > 50 ? candidate[..50] : candidate;
+    }
+
+    /// <summary>SHA-256 password hash (same algorithm as AuthenticationService).</summary>
+    private static string HashPassword(string password)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(password));
+        return Convert.ToBase64String(bytes);
     }
 }
 

--- a/backend/src/Shared/MultiTenancy/TenantManagement/TenantProvisioningJob.cs
+++ b/backend/src/Shared/MultiTenancy/TenantManagement/TenantProvisioningJob.cs
@@ -1,0 +1,74 @@
+using Hangfire;
+using IMS.Modular.Modules.Billing.Application.Services;
+using IMS.Modular.Shared.Abstractions;
+
+namespace IMS.Modular.Shared.MultiTenancy.TenantManagement;
+
+/// <summary>
+/// US-092: Hangfire background job that finalises new-tenant provisioning after signup.
+///
+/// Steps:
+///   1. Set up billing subscription via IBillingService.
+///   2. Send welcome email via IEmailService.
+///   3. Mark TenantEntity.IsActive = true.
+///
+/// On failure: logs the error, sets IsActive = false and records an error note so the
+/// platform operator can investigate.  Hangfire will retry up to 3 times automatically.
+/// </summary>
+public sealed class TenantProvisioningJob(
+    TenantDbContext tenantDb,
+    IBillingService billingService,
+    IEmailService emailService,
+    ILogger<TenantProvisioningJob> logger)
+{
+    [AutomaticRetry(Attempts = 3)]
+    public async Task ExecuteAsync(string tenantId, string planId, string adminEmail)
+    {
+        logger.LogInformation(
+            "[TenantProvisioning] Starting for tenantId={TenantId} plan={Plan}",
+            tenantId, planId);
+
+        var tenant = await tenantDb.Tenants.FindAsync(tenantId);
+        if (tenant is null)
+        {
+            logger.LogError(
+                "[TenantProvisioning] Tenant {TenantId} not found — skipping.", tenantId);
+            return;
+        }
+
+        try
+        {
+            // 1. Create / retrieve billing subscription
+            await billingService.GetOrCreateSubscriptionAsync(tenantId, planId);
+
+            // 2. Send welcome email
+            var subject = "Welcome to IMS — your account is ready!";
+            var body = $"""
+                <h2>Your organisation has been provisioned!</h2>
+                <p>Tenant: <strong>{tenantId}</strong></p>
+                <p>Plan: <strong>{planId}</strong></p>
+                <p>You can now log in at <a href="https://app.ims.io">https://app.ims.io</a></p>
+                """;
+            await emailService.SendAsync(adminEmail, subject, body);
+
+            // 3. Activate tenant
+            tenant.IsActive = true;
+            await tenantDb.SaveChangesAsync();
+
+            logger.LogInformation(
+                "[TenantProvisioning] Tenant {TenantId} provisioned and activated.", tenantId);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex,
+                "[TenantProvisioning] Failed to provision tenant {TenantId}.", tenantId);
+
+            // Mark as failed so the operator can identify the broken tenants
+            tenant.IsActive = false;
+            tenant.Notes = $"Provisioning failed at {DateTime.UtcNow:O}: {ex.Message}";
+            try { await tenantDb.SaveChangesAsync(); } catch { /* best-effort */ }
+
+            throw; // allow Hangfire to retry
+        }
+    }
+}

--- a/backend/src/Shared/RateLimiting/RateLimitingExtensions.cs
+++ b/backend/src/Shared/RateLimiting/RateLimitingExtensions.cs
@@ -26,6 +26,9 @@ public static class RateLimitingExtensions
 
         /// <summary>Global fallback limiter applied to all endpoints.</summary>
         public const string Global = "GlobalPolicy";
+
+        /// <summary>US-092: Per-IP limiter for self-service tenant signup (5/hour).</summary>
+        public const string Signup = "SignupPolicy";
     }
 
     // ── Default values (used when appsettings.json section is missing) ──────
@@ -40,6 +43,11 @@ public static class RateLimitingExtensions
         public const int GlobalPermitLimit = 100;
         public const int GlobalWindowSeconds = 60;
         public const int GlobalQueueLimit = 10;
+
+        // Signup policy defaults (US-092): 5 requests per hour per IP
+        public const int SignupPermitLimit = 5;
+        public const int SignupWindowSeconds = 3600;
+        public const int SignupQueueLimit = 0;
     }
 
     /// <summary>
@@ -96,6 +104,27 @@ public static class RateLimitingExtensions
                         Window = TimeSpan.FromSeconds(authWindowSeconds),
                         QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
                         QueueLimit = authQueueLimit,
+                        AutoReplenishment = true
+                    });
+            });
+
+            // ── Signup Policy (per-IP, fixed window — 5/hour) ─────────────
+            var signupPermitLimit = section.GetValue("Signup:PermitLimit", Defaults.SignupPermitLimit);
+            var signupWindowSeconds = section.GetValue("Signup:WindowSeconds", Defaults.SignupWindowSeconds);
+            var signupQueueLimit = section.GetValue("Signup:QueueLimit", Defaults.SignupQueueLimit);
+
+            options.AddPolicy(Policies.Signup, httpContext =>
+            {
+                var clientIp = GetClientIpAddress(httpContext);
+
+                return RateLimitPartition.GetFixedWindowLimiter(
+                    partitionKey: clientIp,
+                    factory: _ => new FixedWindowRateLimiterOptions
+                    {
+                        PermitLimit = signupPermitLimit,
+                        Window = TimeSpan.FromSeconds(signupWindowSeconds),
+                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                        QueueLimit = signupQueueLimit,
                         AutoReplenishment = true
                     });
             });

--- a/backend/src/appsettings.json
+++ b/backend/src/appsettings.json
@@ -92,7 +92,8 @@
     "EnableFullTextSearch": true,
     "UseIssuesMicroservice": false,
     "EnableMultiTenancy": false,
-    "UseKeycloak": false
+    "UseKeycloak": false,
+    "UseStripe": false
   },
   "Meilisearch": {
     "Host": "http://meilisearch:7700",
@@ -122,5 +123,10 @@
     "Audience": "ims-backend",
     "ClientId": "ims-frontend",
     "RequireHttpsMetadata": false
+  },
+  "Stripe": {
+    "SecretKey": "",
+    "WebhookSecret": "",
+    "PublishableKey": ""
   }
 }

--- a/backend/tests/Modules/Billing/BillingServiceTests.cs
+++ b/backend/tests/Modules/Billing/BillingServiceTests.cs
@@ -1,0 +1,116 @@
+using FluentAssertions;
+using IMS.Modular.Modules.Billing.Application.Services;
+using IMS.Modular.Modules.Billing.Domain.Entities;
+using IMS.Modular.Modules.Billing.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace IMS.Modular.Tests.Modules.Billing;
+
+/// <summary>
+/// US-091: Unit tests for BillingService using EF InMemory.
+/// </summary>
+public class BillingServiceTests : IDisposable
+{
+    private readonly BillingDbContext _db;
+    private readonly BillingService _sut;
+
+    public BillingServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<BillingDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _db = new BillingDbContext(options);
+
+        // Seed plans manually (HasData doesn't run in InMemory)
+        _db.Plans.AddRange(
+            new Plan { Id = "free", Name = "Free", Description = "Free plan", MaxIssuesPerMonth = 50, MaxUsers = null, MaxTenants = 1, PriceMonthly = 0m, IsActive = true },
+            new Plan { Id = "pro", Name = "Pro", Description = "Pro plan", MaxIssuesPerMonth = null, MaxUsers = 5, MaxTenants = null, PriceMonthly = 49m, IsActive = true },
+            new Plan { Id = "enterprise", Name = "Enterprise", Description = "Enterprise plan", MaxIssuesPerMonth = null, MaxUsers = null, MaxTenants = null, PriceMonthly = 0m, IsActive = true }
+        );
+        _db.SaveChanges();
+
+        _sut = new BillingService(_db);
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task CheckQuotaAsync_FreePlan_UnderLimit_ReturnsTrue()
+    {
+        // Arrange
+        var tenantId = "tenant-free-under";
+        _db.Subscriptions.Add(new Subscription { TenantId = tenantId, PlanId = "free", Status = "active" });
+        var now = DateTime.UtcNow;
+        _db.UsageRecords.Add(new UsageRecord
+        {
+            TenantId = tenantId, ResourceType = "issues",
+            Count = 40, Year = now.Year, Month = now.Month
+        });
+        await _db.SaveChangesAsync();
+
+        // Act
+        var result = await _sut.CheckQuotaAsync(tenantId, "issues");
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task CheckQuotaAsync_FreePlan_AtLimit_ReturnsFalse()
+    {
+        // Arrange
+        var tenantId = "tenant-free-at-limit";
+        _db.Subscriptions.Add(new Subscription { TenantId = tenantId, PlanId = "free", Status = "active" });
+        var now = DateTime.UtcNow;
+        _db.UsageRecords.Add(new UsageRecord
+        {
+            TenantId = tenantId, ResourceType = "issues",
+            Count = 50, Year = now.Year, Month = now.Month
+        });
+        await _db.SaveChangesAsync();
+
+        // Act
+        var result = await _sut.CheckQuotaAsync(tenantId, "issues");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IncrementUsageAsync_IncrementsCount()
+    {
+        // Arrange
+        var tenantId = "tenant-increment";
+        var now = DateTime.UtcNow;
+        _db.UsageRecords.Add(new UsageRecord
+        {
+            TenantId = tenantId, ResourceType = "issues",
+            Count = 5, Year = now.Year, Month = now.Month
+        });
+        await _db.SaveChangesAsync();
+
+        // Act
+        await _sut.IncrementUsageAsync(tenantId, "issues");
+
+        // Assert
+        var usage = await _db.UsageRecords.FirstAsync(u =>
+            u.TenantId == tenantId && u.ResourceType == "issues");
+        usage.Count.Should().Be(6);
+    }
+
+    [Fact]
+    public async Task OverridePlanAsync_ChangesPlan()
+    {
+        // Arrange
+        var tenantId = "tenant-override";
+        _db.Subscriptions.Add(new Subscription { TenantId = tenantId, PlanId = "free", Status = "active" });
+        await _db.SaveChangesAsync();
+
+        // Act
+        await _sut.OverridePlanAsync(tenantId, "pro");
+
+        // Assert
+        var subscription = await _db.Subscriptions.FirstAsync(s => s.TenantId == tenantId);
+        subscription.PlanId.Should().Be("pro");
+    }
+}

--- a/backend/tests/Modules/Billing/QuotaBehaviorTests.cs
+++ b/backend/tests/Modules/Billing/QuotaBehaviorTests.cs
@@ -1,0 +1,79 @@
+using FluentAssertions;
+using IMS.Modular.Modules.Billing.Application.Behaviors;
+using IMS.Modular.Modules.Billing.Application.Interfaces;
+using IMS.Modular.Modules.Billing.Application.Services;
+using IMS.Modular.Shared.Abstractions;
+using IMS.Modular.Shared.MultiTenancy;
+using MediatR;
+using Moq;
+
+namespace IMS.Modular.Tests.Modules.Billing;
+
+/// <summary>
+/// US-091: Unit tests for QuotaBehavior MediatR pipeline.
+/// </summary>
+public class QuotaBehaviorTests
+{
+    private readonly Mock<ITenantService> _tenantServiceMock = new();
+    private readonly Mock<IBillingService> _billingServiceMock = new();
+
+    [Fact]
+    public async Task NonIRequiresQuota_PassesThrough()
+    {
+        // Arrange
+        var behavior = new QuotaBehavior<NonQuotaRequest, Unit>(
+            _tenantServiceMock.Object, _billingServiceMock.Object);
+        var wasCalled = false;
+        RequestHandlerDelegate<Unit> next = (ct) => { wasCalled = true; return Task.FromResult(Unit.Value); };
+
+        // Act
+        await behavior.Handle(new NonQuotaRequest(), next, CancellationToken.None);
+
+        // Assert
+        wasCalled.Should().BeTrue();
+        _billingServiceMock.Verify(b => b.CheckQuotaAsync(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task IRequiresQuota_UnderQuota_PassesThrough()
+    {
+        // Arrange
+        _tenantServiceMock.Setup(t => t.TenantId).Returns("tenant-1");
+        _billingServiceMock.Setup(b => b.CheckQuotaAsync("tenant-1", "issues")).ReturnsAsync(true);
+
+        var behavior = new QuotaBehavior<QuotaRequest, Unit>(
+            _tenantServiceMock.Object, _billingServiceMock.Object);
+        var wasCalled = false;
+        RequestHandlerDelegate<Unit> next = (ct) => { wasCalled = true; return Task.FromResult(Unit.Value); };
+
+        // Act
+        await behavior.Handle(new QuotaRequest(), next, CancellationToken.None);
+
+        // Assert
+        wasCalled.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IRequiresQuota_OverQuota_ThrowsQuotaExceededException()
+    {
+        // Arrange
+        _tenantServiceMock.Setup(t => t.TenantId).Returns("tenant-over");
+        _billingServiceMock.Setup(b => b.CheckQuotaAsync("tenant-over", "issues")).ReturnsAsync(false);
+
+        var behavior = new QuotaBehavior<QuotaRequest, Unit>(
+            _tenantServiceMock.Object, _billingServiceMock.Object);
+        RequestHandlerDelegate<Unit> next = (ct) => Task.FromResult(Unit.Value);
+
+        // Act
+        var act = async () => await behavior.Handle(new QuotaRequest(), next, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<QuotaExceededException>();
+    }
+}
+
+// ── Test request types ────────────────────────────────────────────────────────
+
+public record NonQuotaRequest : IRequest<Unit>;
+
+public record QuotaRequest : IRequest<Unit>, IRequiresQuota;

--- a/backend/tests/Modules/Billing/TenantSignupTests.cs
+++ b/backend/tests/Modules/Billing/TenantSignupTests.cs
@@ -1,0 +1,200 @@
+using FluentAssertions;
+using FluentValidation;
+using IMS.Modular.Modules.Auth.Domain.Entities;
+using IMS.Modular.Modules.Auth.Infrastructure;
+using IMS.Modular.Modules.Billing.Application.Services;
+using IMS.Modular.Modules.Billing.Infrastructure;
+using IMS.Modular.Shared.Abstractions;
+using IMS.Modular.Shared.MultiTenancy.TenantManagement;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+
+namespace IMS.Modular.Tests.Modules.Billing;
+
+/// <summary>
+/// US-092: Unit tests for tenant signup — validator, slug generation, endpoint logic.
+/// Uses EF Core InMemory to avoid WebApplicationFactory startup issues.
+/// </summary>
+public class TenantSignupTests : IDisposable
+{
+    private readonly TenantDbContext _tenantDb;
+    private readonly AuthDbContext _authDb;
+    private readonly SignupValidator _validator;
+
+    public TenantSignupTests()
+    {
+        var tenantOpts = new DbContextOptionsBuilder<TenantDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _tenantDb = new TenantDbContext(tenantOpts);
+
+        var authOpts = new DbContextOptionsBuilder<AuthDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _authDb = new AuthDbContext(authOpts);
+
+        // Seed required Auth role so signup user creation works
+        _authDb.Roles.Add(new Role
+        {
+            Id = Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            Name = "Admin",
+            Description = "Administrator"
+        });
+        _authDb.SaveChanges();
+
+        _validator = new SignupValidator();
+    }
+
+    public void Dispose()
+    {
+        _tenantDb.Dispose();
+        _authDb.Dispose();
+    }
+
+    // ── Validator tests ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Signup_ValidRequest_PassesValidation()
+    {
+        var req = new SignupRequest("Acme Corp", "admin@acme.com", "Password1!", "free");
+
+        var result = await _validator.ValidateAsync(req);
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Signup_InvalidEmail_FailsValidation_Returns400()
+    {
+        var req = new SignupRequest("Acme Corp", "not-an-email", "Password1!", "free");
+
+        var result = await _validator.ValidateAsync(req);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Email");
+    }
+
+    [Fact]
+    public async Task Signup_ShortPassword_FailsValidation_Returns400()
+    {
+        var req = new SignupRequest("Acme Corp", "admin@acme.com", "short", "free");
+
+        var result = await _validator.ValidateAsync(req);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Password");
+    }
+
+    [Fact]
+    public async Task Signup_InvalidPlan_FailsValidation()
+    {
+        var req = new SignupRequest("Acme Corp", "admin@acme.com", "Password1!", "enterprise");
+
+        var result = await _validator.ValidateAsync(req);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Plan");
+    }
+
+    [Fact]
+    public async Task Signup_ShortOrgName_FailsValidation()
+    {
+        var req = new SignupRequest("AB", "admin@acme.com", "Password1!", "free");
+
+        var result = await _validator.ValidateAsync(req);
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "OrgName");
+    }
+
+    // ── Slug generation & entity creation tests ───────────────────────────────
+
+    [Fact]
+    public async Task Signup_ValidData_CreatesTenantWithIsActiveFalse()
+    {
+        var orgName  = $"Test Corp {Guid.NewGuid():N}"[..20];
+        var email    = $"admin-{Guid.NewGuid():N}"[..16] + "@example.com";
+        var req      = new SignupRequest(orgName, email, "Password1!", "starter");
+        var jobMock  = new Mock<Hangfire.IBackgroundJobClient>();
+
+        // Act — simulate what the endpoint handler does
+        var validation = await _validator.ValidateAsync(req);
+        validation.IsValid.Should().BeTrue();
+
+        var slug = GenerateTenantSlug(orgName);
+        slug.Should().NotBeNullOrWhiteSpace();
+        slug.Should().MatchRegex("^[a-z0-9-]+$");
+
+        var alreadyExists = await _tenantDb.Tenants.AnyAsync(t => t.Id == slug);
+        alreadyExists.Should().BeFalse();
+
+        var tenant = new TenantEntity
+        {
+            Id           = slug,
+            Name         = orgName.Trim(),
+            Plan         = "starter",
+            ContactEmail = email,
+            IsActive     = false,
+            CreatedAt    = DateTime.UtcNow,
+            Notes        = "Provisioning"
+        };
+        _tenantDb.Tenants.Add(tenant);
+        await _tenantDb.SaveChangesAsync();
+
+        // Assert
+        var saved = await _tenantDb.Tenants.FindAsync(slug);
+        saved.Should().NotBeNull();
+        saved!.IsActive.Should().BeFalse();
+        saved.Plan.Should().Be("starter");
+        saved.ContactEmail.Should().Be(email);
+    }
+
+    [Fact]
+    public async Task Signup_DuplicateOrgName_ShouldBeDetectedAs409()
+    {
+        var orgName = "Duplicate Corp " + Guid.NewGuid().ToString("N")[..6];
+        var slug    = GenerateTenantSlug(orgName);
+
+        // Seed an existing tenant with the same slug
+        _tenantDb.Tenants.Add(new TenantEntity
+        {
+            Id        = slug,
+            Name      = orgName,
+            Plan      = "free",
+            IsActive  = true,
+            CreatedAt = DateTime.UtcNow
+        });
+        await _tenantDb.SaveChangesAsync();
+
+        // Assert conflict is detected
+        var conflict = await _tenantDb.Tenants.AnyAsync(t => t.Id == slug);
+        conflict.Should().BeTrue("second signup with same org name should detect a 409 conflict");
+    }
+
+    // ── Slug generation edge cases ────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("Acme Corp",          "acme-corp")]
+    [InlineData("  My Cool Org  ",    "my-cool-org")]
+    [InlineData("Hello & World!",     "hello-world")]
+    [InlineData("A B  C",             "a-b-c")]
+    public void GenerateTenantSlug_ProducesExpectedSlug(string orgName, string expected)
+    {
+        var slug = GenerateTenantSlug(orgName);
+        slug.Should().Be(expected);
+    }
+
+    // ── Helper (mirrors the private method in TenantEndpoints) ───────────────
+
+    private static string GenerateTenantSlug(string orgName)
+    {
+        var slug = orgName.ToLowerInvariant().Trim();
+        slug = System.Text.RegularExpressions.Regex.Replace(slug, @"\s+", "-");
+        slug = System.Text.RegularExpressions.Regex.Replace(slug, @"[^a-z0-9\-]", "");
+        slug = System.Text.RegularExpressions.Regex.Replace(slug, @"-{2,}", "-");
+        slug = slug.Trim('-');
+        return slug.Length > 50 ? slug[..50] : slug;
+    }
+}

--- a/frontend/apps/next-shell/app/(auth)/signup/page.tsx
+++ b/frontend/apps/next-shell/app/(auth)/signup/page.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { toast } from "sonner";
+import Link from "next/link";
+import { Eye, EyeOff, Building2, CheckCircle2 } from "lucide-react";
+
+const PLANS = [
+  { id: "free", label: "Free", price: "$0/mo", description: "Up to 50 issues/month · 1 user" },
+  { id: "starter", label: "Starter", price: "$29/mo", description: "Unlimited issues · 5 users" },
+  { id: "pro", label: "Pro", price: "$99/mo", description: "Unlimited everything · priority support" },
+] as const;
+
+const schema = z.object({
+  orgName: z.string().min(3, "Min 3 chars").max(50, "Max 50 chars"),
+  email: z.string().email("Enter a valid email"),
+  password: z.string().min(8, "Min 8 characters"),
+  plan: z.enum(["free", "starter", "pro"]),
+  hp_field: z.string().max(0, "Bot detected"),
+});
+type FormData = z.infer<typeof schema>;
+
+export default function SignupPage() {
+  const [showPassword, setShowPassword] = useState(false);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    watch,
+    formState: { errors, isSubmitting },
+  } = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: { plan: "free", hp_field: "" },
+  });
+
+  const selectedPlan = watch("plan");
+
+  const onSubmit = async (data: FormData) => {
+    if (data.hp_field) {
+      toast.error("Signup rejected.");
+      return;
+    }
+
+    try {
+      const res = await fetch("/api/auth/signup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          orgName: data.orgName,
+          email: data.email,
+          password: data.password,
+          plan: data.plan,
+          hp_field: data.hp_field,
+        }),
+      });
+
+      if (res.status === 409) {
+        toast.error("An organisation with that name already exists. Try a different name.");
+        return;
+      }
+
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        const detail =
+          err?.errors
+            ? Object.values(err.errors as Record<string, string[]>)
+                .flat()
+                .join(", ")
+            : err?.message ?? "Signup failed. Please try again.";
+        toast.error(detail);
+        return;
+      }
+
+      const json = await res.json();
+      setSuccess(json?.message ?? "Check your email to confirm your account.");
+    } catch {
+      toast.error("Unable to reach the server. Please try again.");
+    }
+  };
+
+  if (success) {
+    return (
+      <div className="bg-white/10 backdrop-blur-md rounded-2xl p-8 border border-white/20 shadow-2xl text-center">
+        <CheckCircle2 className="mx-auto text-green-400 mb-4" size={48} />
+        <h2 className="text-xl font-semibold text-white mb-2">You&apos;re almost there!</h2>
+        <p className="text-blue-200 text-sm">{success}</p>
+        <Link
+          href="/login"
+          className="mt-6 inline-block text-sm text-blue-300 hover:text-white transition-colors"
+        >
+          ← Back to login
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white/10 backdrop-blur-md rounded-2xl p-8 border border-white/20 shadow-2xl">
+      <h2 className="text-xl font-semibold text-white mb-6">Create your organisation</h2>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+        {/* Honeypot — hidden from real users */}
+        <input {...register("hp_field")} type="text" className="hidden" tabIndex={-1} autoComplete="off" />
+
+        {/* Org Name */}
+        <div>
+          <label htmlFor="orgName" className="block text-sm font-medium text-blue-200 mb-1">
+            Organisation name
+          </label>
+          <div className="relative">
+            <input
+              {...register("orgName")}
+              id="orgName"
+              type="text"
+              placeholder="Acme Corp"
+              className="w-full px-4 py-2.5 rounded-lg bg-white/10 border border-white/20 text-white placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-blue-400 pl-10"
+            />
+            <Building2
+              size={16}
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-white/40"
+            />
+          </div>
+          {errors.orgName && (
+            <p className="text-red-400 text-xs mt-1">{errors.orgName.message}</p>
+          )}
+        </div>
+
+        {/* Email */}
+        <div>
+          <label htmlFor="email" className="block text-sm font-medium text-blue-200 mb-1">
+            Work email
+          </label>
+          <input
+            {...register("email")}
+            id="email"
+            type="email"
+            placeholder="you@company.com"
+            className="w-full px-4 py-2.5 rounded-lg bg-white/10 border border-white/20 text-white placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-blue-400"
+          />
+          {errors.email && (
+            <p className="text-red-400 text-xs mt-1">{errors.email.message}</p>
+          )}
+        </div>
+
+        {/* Password */}
+        <div>
+          <label htmlFor="password" className="block text-sm font-medium text-blue-200 mb-1">
+            Password
+          </label>
+          <div className="relative">
+            <input
+              {...register("password")}
+              id="password"
+              type={showPassword ? "text" : "password"}
+              placeholder="••••••••"
+              className="w-full px-4 py-2.5 rounded-lg bg-white/10 border border-white/20 text-white placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-blue-400 pr-10"
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword(!showPassword)}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-white/50 hover:text-white"
+            >
+              {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+            </button>
+          </div>
+          {errors.password && (
+            <p className="text-red-400 text-xs mt-1">{errors.password.message}</p>
+          )}
+        </div>
+
+        {/* Plan selector */}
+        <div>
+          <p className="block text-sm font-medium text-blue-200 mb-2">Plan</p>
+          <div className="grid grid-cols-3 gap-2">
+            {PLANS.map((plan) => (
+              <button
+                key={plan.id}
+                type="button"
+                onClick={() => setValue("plan", plan.id, { shouldValidate: true })}
+                className={`rounded-lg p-3 text-left border transition-colors ${
+                  selectedPlan === plan.id
+                    ? "border-blue-400 bg-blue-500/20 text-white"
+                    : "border-white/20 bg-white/5 text-white/70 hover:border-white/40"
+                }`}
+              >
+                <div className="text-xs font-bold">{plan.label}</div>
+                <div className="text-xs font-semibold text-blue-300 mt-0.5">{plan.price}</div>
+                <div className="text-[10px] text-white/50 mt-1 leading-tight">{plan.description}</div>
+              </button>
+            ))}
+          </div>
+          {errors.plan && (
+            <p className="text-red-400 text-xs mt-1">{errors.plan.message}</p>
+          )}
+        </div>
+
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="w-full flex items-center justify-center gap-2 py-2.5 px-4 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white font-medium rounded-lg transition-colors"
+        >
+          {isSubmitting ? (
+            <span className="animate-spin h-4 w-4 border-2 border-white border-t-transparent rounded-full" />
+          ) : null}
+          {isSubmitting ? "Creating account…" : "Create account"}
+        </button>
+      </form>
+
+      <p className="mt-6 text-center text-sm text-blue-300">
+        Already have an account?{" "}
+        <Link href="/login" className="text-white font-medium hover:underline">
+          Sign in
+        </Link>
+      </p>
+    </div>
+  );
+}

--- a/frontend/apps/next-shell/app/api/auth/signup/route.ts
+++ b/frontend/apps/next-shell/app/api/auth/signup/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const BACKEND_URL = process.env.IMS_API_URL ?? "http://localhost:5049";
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+
+  // Honeypot check: bots fill hidden fields that humans never touch
+  if (body.hp_field) {
+    return NextResponse.json({ message: "Bad request." }, { status: 400 });
+  }
+
+  const { orgName, email, password, plan } = body;
+
+  const upstream = await fetch(`${BACKEND_URL}/api/tenants/signup`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ orgName, email, password, plan }),
+  });
+
+  if (!upstream.ok) {
+    const err = await upstream.json().catch(() => ({ message: "Signup failed." }));
+    return NextResponse.json(err, { status: upstream.status });
+  }
+
+  const data = await upstream.json();
+  return NextResponse.json(data, { status: 202 });
+}


### PR DESCRIPTION
## US-091 — Billing & Subscription

Closes #123

### O que foi implementado
- **Módulo `Billing`** completo (Domain → Application → Infrastructure → API)
- Entidades: `Plan`, `Subscription`, `UsageRecord` com `BillingDbContext` (EF Core, migrations automáticas)
- **3 planos** seedados: Free (50 issues/mês), Pro (ilimitado, até 5 users), Enterprise (custom)
- **`IBillingService`** / `BillingService`: quota checks, usage tracking, ciclo de vida de subscriptions
- **`IStripeService`** / `NoOpStripeService`: integração mockada em dev (ativada via feature flag `UseStripe`)
- **`QuotaBehavior<,>`** MediatR pipeline: interceta comandos com `IRequiresQuota` → HTTP 402 quando quota excedida
- `CreateIssueCommand` agora implementa `IRequiresQuota` — quota aplicada transparentemente

### Endpoints
| Método | Rota | Auth |
|---|---|---|
| `GET` | `/api/billing/plans` | Público |
| `GET` | `/api/billing/subscription` | Autenticado |
| `POST` | `/api/billing/admin/override` | Admin |
| `POST` | `/api/billing/checkout` | Autenticado |
| `POST` | `/api/billing/webhook` | Público (Stripe) |

### Testes
- `BillingServiceTests.cs` — 4 testes (quota free, quota pro, increment, override plan)
- `QuotaBehaviorTests.cs` — 3 testes (pass-through, under quota, over quota → 402)

---

## US-092 — Self-service Tenant Onboarding

Closes #124

### O que foi implementado
- **`POST /api/tenants/signup`** — endpoint público, rate-limited (5/hora por IP, nova policy `Signup`)
- Auto-geração de tenantId slug a partir do `orgName`
- `SignupValidator` (FluentValidation): orgName, email, password, plan
- **`TenantProvisioningJob`** (Hangfire): billing setup → email de boas-vindas → ativa tenant (`IsActive = true`)
- Honeypot field anti-bot na criação de tenant
- Retorna `202 Accepted` com `{ tenantId, message }`
- **Frontend**: página `/signup` com seletor de planos (cards Free/Starter/Pro), honeypot, tratamento de erros
- **BFF route** `app/api/auth/signup/route.ts` com verificação do honeypot server-side

### Testes
- `TenantSignupTests.cs` — 11 testes (slug generation, validação, 409 conflict, entity creation)

---

## Cross-cutting changes
- `QuotaExceededException` → mapeada para HTTP 402 no `ExceptionHandlingMiddleware`
- `FeatureFlags.UseStripe` adicionado
- `appsettings.json`: seção `Stripe:{}` adicionada
- `Program.cs`: módulo Billing registrado, `QuotaBehavior` no pipeline MediatR, endpoints e init DB

**Build**: 0 erros | **Testes**: 18/18 Billing + 11/11 TenantSignup ✅